### PR TITLE
Add method call support to parser

### DIFF
--- a/src/parser/arithmetic.rs
+++ b/src/parser/arithmetic.rs
@@ -169,6 +169,17 @@ where
                 PowRhs::FloatLit { value, span } => MulRhs::FloatLit { value, span },
                 PowRhs::BoolLit { value, span } => MulRhs::BoolLit { value, span },
                 PowRhs::Call { name, args, span } => MulRhs::Call { name, args, span },
+                PowRhs::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                    span,
+                } => MulRhs::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                    span,
+                },
             }
         }),
         select! { Token::LeftParen(t) => t.position }
@@ -225,6 +236,17 @@ where
                 PowRhs::FloatLit { value, span } => MulLhs::FloatLit { value, span },
                 PowRhs::BoolLit { value, span } => MulLhs::BoolLit { value, span },
                 PowRhs::Call { name, args, span } => MulLhs::Call { name, args, span },
+                PowRhs::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                    span,
+                } => MulLhs::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                    span,
+                },
             }
         }),
         select! { Token::LeftParen(t) => t.position }


### PR DESCRIPTION
This commit adds comprehensive support for method calls in the CAD-DSL parser:

AST Changes:
- Added MethodCall variant to Expr enum and all precedence levels
- Implemented HasSpan and Display traits for MethodCall
- Added From conversions for MethodCall across all precedence levels

Parser Changes:
- Updated atom parser to handle method call syntax (obj.method(args))
- Method calls support chaining (obj.method1().method2())
- Can call methods on any expression, including function call results
- Updated arithmetic parsers to handle MethodCall in match statements

Tests:
- Added 7 comprehensive tests for method call parsing
- Tests cover: no args, one arg, multiple args, chaining, on function calls,
  with expression args, and in expressions
- All 131 tests passing

The implementation follows the existing patterns for function calls and
properly integrates with the precedence hierarchy. Method calls have high
precedence (atom level) and bind left-to-right.