### PR TITLE
Replace last assert!(matches!(...)) with assert_matches!(...) and document in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ This project uses Nix for development environment management. Use `nix develop` 
 - `./hooks/install-hooks.sh` - Install pre-commit hooks for code quality enforcement
 - Pre-commit hook runs: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`
 
+## Coding Standards
+
+### Testing Best Practices
+
+- **Use `assert_matches!` macro**: Always use `assert_matches!(value, Pattern { .. })` instead of `assert!(matches!(value, Pattern { .. }))` in tests. The `assert_matches!` macro provides clearer error messages when assertions fail.
+
 ## Code Architecture
 
 ### Core Components

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use crate::ast::expr::*;
     use crate::lexer::{LineColumn, Span};
 
@@ -130,7 +131,7 @@ mod tests {
             span: dummy_span(),
         };
 
-        assert!(matches!(add, Expr::Add { .. }));
+        assert_matches!(add, Expr::Add { .. });
     }
 
     #[test]


### PR DESCRIPTION
- Replace remaining assert!(matches!(add, Expr::Add { .. })) in ast/tests.rs
- Add assert_matches! import to ast/tests.rs
- Add "Coding Standards" section to CLAUDE.md
- Document best practice: use assert_matches! for clearer error messages