### PR TITLE
Add struct definition parsing support

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -33,7 +33,7 @@ mod tests;
 pub use span::HasSpan;
 
 // Re-export types
-pub use types::{FunctionParam, Stmt, Type};
+pub use types::{FunctionParam, Stmt, StructField, Type};
 
 // Re-export all expression types
 pub use expr::{AddLhs, AddRhs, Atom, CmpLhs, CmpRhs, Expr, MulLhs, MulRhs, PowLhs, PowRhs};

--- a/src/ast/tests.rs
+++ b/src/ast/tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use crate::ast::expr::*;
     use crate::lexer::{LineColumn, Span};
+    use assert_matches::assert_matches;
 
     // Helper function to create a dummy span for testing
     fn dummy_span() -> Span {

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -59,6 +59,25 @@ impl HasSpan for FunctionParam {
 }
 
 // ============================================================================
+// Struct Field
+// ============================================================================
+
+/// Struct field with name and type
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructField {
+    pub name: String,
+    pub name_span: Span,
+    pub type_annotation: Type,
+    pub span: Span,
+}
+
+impl HasSpan for StructField {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
 // Statements
 // ============================================================================
 
@@ -91,6 +110,21 @@ pub enum Stmt<'src> {
         return_expr: Option<Expr<'src>>,
         span: Span,
     },
+
+    /// Struct definition with fields and methods
+    /// Examples:
+    ///   struct Point { x: f64, y: f64 }
+    ///   struct Circle { center: Point, radius: f64, fn area() -> f64 { ... } }
+    ///   struct Sketch { container entities, origin: Point }
+    StructDef {
+        name: String,
+        name_span: Span,
+        /// Optional container field name
+        container: Option<(String, Span)>,
+        fields: Vec<StructField>,
+        methods: Vec<Stmt<'src>>,
+        span: Span,
+    },
 }
 
 impl<'src> HasSpan for Stmt<'src> {
@@ -98,6 +132,7 @@ impl<'src> HasSpan for Stmt<'src> {
         match self {
             Stmt::Let { span, .. } => *span,
             Stmt::FunctionDef { span, .. } => *span,
+            Stmt::StructDef { span, .. } => *span,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,10 @@ fn main() {
                 }
             };
 
-            // Parse as either a let statement or function definition
+            // Parse as either a let statement, function definition, or struct definition
             use chumsky::primitive::choice;
             let stmt_parser = choice((
+                parser::struct_def(parser::expr_inner()),
                 parser::function_def(parser::expr_inner()),
                 parser::let_stmt(parser::expr_inner()),
             ));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,7 +58,7 @@ mod stmt;
 // ============================================================================
 
 pub use error::report_parse_errors;
-pub use stmt::{function_def, let_stmt};
+pub use stmt::{function_def, let_stmt, struct_def};
 
 // ============================================================================
 // Parser Type Definitions

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -120,6 +120,10 @@ pub fn atom<'src>(
                 },
             }
         }),
+        // self keyword
+        select! {
+            Token::SelfKw(t) => Atom::Var { name: "self", span: Span { start: t.position, lines: 0, end_column: t.position.column + 4 } },
+        },
         // Finally plain variable (no function call)
         select! {
             Token::Identifier(t) => Atom::Var { name: t.name, span: t.span },

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -1,7 +1,7 @@
 //! Statement and type annotation parsers
 
 use crate::ast::span::HasSpan;
-use crate::ast::{FunctionParam, Stmt, Type};
+use crate::ast::{FunctionParam, Stmt, StructField, Type};
 use crate::lexer::Token;
 use crate::parser::ParseError;
 use chumsky::prelude::*;
@@ -276,4 +276,162 @@ pub fn function_def<'src>(
         },
     )
     .labelled("function definition")
+}
+
+// ============================================================================
+// Struct Definition Parser
+// ============================================================================
+
+/// Parse a struct field: name: Type
+fn struct_field<'src>()
+-> impl Parser<'src, &'src [Token<'src>], StructField, ParseError<'src>> + Clone {
+    use crate::lexer::Span;
+
+    let colon = select! { Token::Colon(_) => () };
+
+    select! {
+        Token::Identifier(t) => (t.name.to_string(), t.span),
+    }
+    .labelled("field name")
+    .then_ignore(colon)
+    .then(type_annotation())
+    .map(|((name, name_span), type_annotation)| {
+        let type_span = type_annotation.span();
+        let span = if name_span.start.line == type_span.start.line {
+            Span {
+                start: name_span.start,
+                lines: 0,
+                end_column: type_span.end_column,
+            }
+        } else {
+            Span {
+                start: name_span.start,
+                lines: type_span.start.line - name_span.start.line + type_span.lines,
+                end_column: type_span.end_column,
+            }
+        };
+        StructField {
+            name,
+            name_span,
+            type_annotation,
+            span,
+        }
+    })
+    .labelled("struct field")
+}
+
+/// Parse a container field declaration: container name
+fn container_field<'src>()
+-> impl Parser<'src, &'src [Token<'src>], (String, crate::lexer::Span), ParseError<'src>> + Clone {
+    select! {
+        Token::Container(t) => t.position,
+    }
+    .then(select! {
+        Token::Identifier(t) => (t.name.to_string(), t.span),
+    })
+    .map(|(_, (name, span))| (name, span))
+    .labelled("container field")
+}
+
+/// Parse a struct definition
+///
+/// Syntax:
+///   struct Name { field1: Type, field2: Type }
+///   struct Name { container entities, field: Type }
+///   struct Name { field: Type, fn method() -> Type { ... } }
+pub fn struct_def<'src>(
+    expr_parser: impl Parser<'src, &'src [Token<'src>], crate::ast::Expr<'src>, ParseError<'src>>
+    + Clone
+    + 'src,
+) -> impl Parser<'src, &'src [Token<'src>], Stmt<'src>, ParseError<'src>> + Clone {
+    use crate::lexer::Span;
+
+    let left_brace = select! { Token::LeftBrace(_) => () };
+    let right_brace = select! { Token::RightBrace(t) => t.position };
+    let comma = select! { Token::Comma(_) => () };
+
+    // Parse struct members: either container field, regular field, or method
+    let member_parser = choice((
+        // Container field
+        container_field().map(MemberItem::Container),
+        // Function definition
+        function_def(expr_parser.clone()).map(MemberItem::Method),
+        // Regular field
+        struct_field().map(MemberItem::Field),
+    ));
+
+    select! {
+        Token::Struct(t) => t.position,
+    }
+    .then(
+        select! {
+            Token::Identifier(t) => (t.name.to_string(), t.span),
+        }
+        .labelled("struct name"),
+    )
+    .then_ignore(left_brace)
+    .then(
+        // Parse members separated by commas (with optional trailing comma)
+        member_parser
+            .separated_by(comma)
+            .allow_trailing()
+            .collect::<Vec<_>>(),
+    )
+    .then(right_brace)
+    .try_map(
+        |(((struct_pos, (name, name_span)), members), brace_pos), span| {
+            // Separate members into container, fields, and methods
+            let mut container = None;
+            let mut fields = Vec::new();
+            let mut methods = Vec::new();
+
+            for member in members {
+                match member {
+                    MemberItem::Container(c) => {
+                        if container.is_some() {
+                            return Err(Rich::custom(
+                                span,
+                                "struct can have at most one container field",
+                            ));
+                        }
+                        container = Some(c);
+                    }
+                    MemberItem::Field(f) => fields.push(f),
+                    MemberItem::Method(m) => methods.push(m),
+                }
+            }
+
+            // Construct span from struct keyword to closing brace
+            let struct_span = if struct_pos.line == brace_pos.line {
+                Span {
+                    start: struct_pos,
+                    lines: 0,
+                    end_column: brace_pos.column + 1,
+                }
+            } else {
+                Span {
+                    start: struct_pos,
+                    lines: brace_pos.line - struct_pos.line,
+                    end_column: brace_pos.column + 1,
+                }
+            };
+
+            Ok(Stmt::StructDef {
+                name,
+                name_span,
+                container,
+                fields,
+                methods,
+                span: struct_span,
+            })
+        },
+    )
+    .labelled("struct definition")
+}
+
+// Helper enum for parsing struct members
+enum MemberItem<'src> {
+    Container((String, crate::lexer::Span)),
+    Field(StructField),
+    Method(Stmt<'src>),
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::ast::{FunctionParam, Stmt, Type};
+use crate::ast::{FunctionParam, Stmt, StructField, Type};
 use crate::lexer;
-use crate::parser::stmt::{function_def, type_annotation};
+use crate::parser::stmt::{function_def, struct_def, type_annotation};
 use assert_matches::assert_matches;
 use std::time::Duration;
 
@@ -1554,6 +1554,7 @@ fn test_let_with_type_and_init() {
             assert_matches!(init, Some(Expr::IntLit { value: 42, .. }));
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -1578,6 +1579,7 @@ fn test_let_with_type_only() {
             assert!(init.is_none());
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -1602,6 +1604,7 @@ fn test_let_with_init_only() {
             assert_matches!(init, Some(Expr::FloatLit { value, .. }) if value == 3.14);
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -1626,6 +1629,7 @@ fn test_let_no_type_no_init() {
             assert!(init.is_none());
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -1666,6 +1670,7 @@ fn test_let_with_expression() {
             }
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -1863,6 +1868,7 @@ fn test_span_let_statement() {
             assert_eq!(span.end_column, 12); // Ends after ';'
         }
         Stmt::FunctionDef { .. } => panic!("Expected Stmt::Let, got FunctionDef"),
+        Stmt::StructDef { .. } => panic!("Expected Stmt::Let, got StructDef"),
     }
 }
 
@@ -2929,5 +2935,313 @@ fn test_function_def_complex_body() {
             assert!(return_expr.is_some());
         }
         other => panic!("Expected Stmt::FunctionDef, got {:?}", other),
+    }
+}
+
+// ============================================================================
+// Struct Definition Tests
+// ============================================================================
+
+#[test]
+fn test_struct_def_basic() {
+    let input = "struct Point { x: f64, y: f64 }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            container,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Point");
+            assert!(container.is_none());
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "x");
+            assert_matches!(fields[0].type_annotation, Type::F64 { .. });
+            assert_eq!(fields[1].name, "y");
+            assert_matches!(fields[1].type_annotation, Type::F64 { .. });
+            assert_eq!(methods.len(), 0);
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_with_container() {
+    let input = "struct Sketch { container entities, origin: Point }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            container,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Sketch");
+            assert!(container.is_some());
+            assert_eq!(container.unwrap().0, "entities");
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "origin");
+            assert_matches!(fields[0].type_annotation, Type::UserDefined { ref name, .. } if name == "Point");
+            assert_eq!(methods.len(), 0);
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_with_method() {
+    let input = "struct Circle { radius: f64, fn area() -> f64 { radius * radius } }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            container,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Circle");
+            assert!(container.is_none());
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "radius");
+            assert_eq!(methods.len(), 1);
+
+            match &methods[0] {
+                Stmt::FunctionDef {
+                    name,
+                    params,
+                    return_type,
+                    ..
+                } => {
+                    assert_eq!(name, "area");
+                    assert_eq!(params.len(), 0);
+                    assert_matches!(return_type, Type::F64 { .. });
+                }
+                other => panic!("Expected FunctionDef, got {:?}", other),
+            }
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_with_transform() {
+    let input = "struct Translate { offset_x: f64, offset_y: f64, fn __transform__(p: &Point) -> Point { p } }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Translate");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(methods.len(), 1);
+
+            match &methods[0] {
+                Stmt::FunctionDef { name, params, .. } => {
+                    assert_eq!(name, "__transform__");
+                    assert_eq!(params.len(), 1);
+                    assert_eq!(params[0].name, "p");
+                    assert_matches!(params[0].type_annotation, Type::Reference { .. });
+                }
+                other => panic!("Expected FunctionDef, got {:?}", other),
+            }
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_complex() {
+    let input = "struct Rectangle { container entities, width: f64, height: f64, fn area() -> f64 { width * height }, fn perimeter() -> f64 { width + height } }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            container,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Rectangle");
+            assert!(container.is_some());
+            assert_eq!(container.unwrap().0, "entities");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "width");
+            assert_eq!(fields[1].name, "height");
+            assert_eq!(methods.len(), 2);
+
+            match &methods[0] {
+                Stmt::FunctionDef { name, .. } => {
+                    assert_eq!(name, "area");
+                }
+                other => panic!("Expected FunctionDef, got {:?}", other),
+            }
+
+            match &methods[1] {
+                Stmt::FunctionDef { name, .. } => {
+                    assert_eq!(name, "perimeter");
+                }
+                other => panic!("Expected FunctionDef, got {:?}", other),
+            }
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_empty() {
+    let input = "struct Empty { }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            container,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Empty");
+            assert!(container.is_none());
+            assert_eq!(fields.len(), 0);
+            assert_eq!(methods.len(), 0);
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_trailing_comma() {
+    let input = "struct Point { x: f64, y: f64, }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef { name, fields, .. } => {
+            assert_eq!(name, "Point");
+            assert_eq!(fields.len(), 2);
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_reference_types() {
+    let input = "struct LineRef { start: &Point, end: &Point }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef { name, fields, .. } => {
+            assert_eq!(name, "LineRef");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "start");
+            assert_matches!(fields[0].type_annotation, Type::Reference { .. });
+            assert_eq!(fields[1].name, "end");
+            assert_matches!(fields[1].type_annotation, Type::Reference { .. });
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_with_self_reference() {
+    let input =
+        "struct Circle { center: Point, radius: f64, fn diameter() -> f64 { self.radius * 2.0 } }";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef {
+            name,
+            fields,
+            methods,
+            ..
+        } => {
+            assert_eq!(name, "Circle");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(methods.len(), 1);
+
+            match &methods[0] {
+                Stmt::FunctionDef {
+                    name, return_expr, ..
+                } => {
+                    assert_eq!(name, "diameter");
+                    assert!(return_expr.is_some());
+                    // The return expression should contain self.radius * 2.0
+                    // We can check that it's a multiplication expression
+                    assert_matches!(return_expr, Some(Expr::Mul { .. }));
+                }
+                other => panic!("Expected FunctionDef, got {:?}", other),
+            }
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_def_multiline() {
+    let input = "struct Point {
+    x: f64,
+    y: f64
+}";
+    let result = parse_with_timeout(
+        input,
+        |tokens| struct_def(expr_inner()).parse(tokens).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Stmt::StructDef { name, fields, .. } => {
+            assert_eq!(name, "Point");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "x");
+            assert_eq!(fields[1].name, "y");
+        }
+        other => panic!("Expected Stmt::StructDef, got {:?}", other),
     }
 }


### PR DESCRIPTION
Implements parsing for struct definitions with the following features:
- Basic struct with fields: struct Name { field1: Type, field2: Type }
- Struct with container: struct Name { container entities, field: Type }
- Struct with methods: struct Name { field: Type, fn method() -> Type { ... } }
- Support for self reference in method bodies: self.field
- Support for __transform__ methods: fn __transform__(p: &Point) -> Point { ... }

Changes:
- Add StructField and StructDef AST nodes to src/ast/types.rs
- Implement struct_def parser in src/parser/stmt.rs with validation for single container
- Add self keyword support in expression parser (src/parser/atoms.rs)
- Export struct_def from parser module and integrate into CLI
- Add comprehensive test suite covering all struct definition features
- Update existing tests to handle new StructDef variant

All tests pass and code follows project style guidelines.