### PR TITLE
Add struct literal computed property support

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -36,4 +36,6 @@ pub use span::HasSpan;
 pub use types::{FunctionParam, Stmt, StructField, Type};
 
 // Re-export all expression types
-pub use expr::{AddLhs, AddRhs, Atom, CmpLhs, CmpRhs, Expr, MulLhs, MulRhs, PowLhs, PowRhs};
+pub use expr::{
+    AddLhs, AddRhs, Atom, CmpLhs, CmpRhs, Expr, MulLhs, MulRhs, PowLhs, PowRhs, StructLitField,
+};

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -4,6 +4,17 @@ use crate::ast::expr::*;
 // Display Implementations
 // ============================================================================
 
+impl<'src> std::fmt::Display for StructLitField<'src> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StructLitField::Field { name, value, .. } => write!(f, "{}: {}", name, value),
+            StructLitField::ComputedProperty { name, value, .. } => {
+                write!(f, "{}() = {}", name, value)
+            }
+        }
+    }
+}
+
 impl<'src> std::fmt::Display for Expr<'src> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -68,11 +79,11 @@ impl<'src> std::fmt::Display for Expr<'src> {
             }
             Expr::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -160,11 +171,11 @@ impl<'src> std::fmt::Display for CmpLhs<'src> {
             }
             CmpLhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -245,11 +256,11 @@ impl<'src> std::fmt::Display for CmpRhs<'src> {
             }
             CmpRhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -330,11 +341,11 @@ impl<'src> std::fmt::Display for AddLhs<'src> {
             }
             AddLhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -413,11 +424,11 @@ impl<'src> std::fmt::Display for AddRhs<'src> {
             }
             AddRhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -496,11 +507,11 @@ impl<'src> std::fmt::Display for MulLhs<'src> {
             }
             MulLhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -576,11 +587,11 @@ impl<'src> std::fmt::Display for MulRhs<'src> {
             }
             MulRhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -655,11 +666,11 @@ impl<'src> std::fmt::Display for PowLhs<'src> {
             }
             PowLhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -735,11 +746,11 @@ impl<'src> std::fmt::Display for PowRhs<'src> {
             }
             PowRhs::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }
@@ -811,11 +822,11 @@ impl<'src> std::fmt::Display for Atom<'src> {
             }
             Atom::StructLit { name, fields, .. } => {
                 write!(f, "{} {{ ", name)?;
-                for (i, (field_name, field_value)) in fields.iter().enumerate() {
+                for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}: {}", field_name, field_value)?;
+                    write!(f, "{}", field)?;
                 }
                 write!(f, " }}")
             }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -3,6 +3,36 @@ use crate::lexer::Span;
 use subenum::subenum;
 
 // ============================================================================
+// Struct Literal Field
+// ============================================================================
+
+/// Represents a field in a struct literal
+#[derive(Debug, Clone, PartialEq)]
+pub enum StructLitField<'src> {
+    /// Regular field assignment: `field: value`
+    Field {
+        name: &'src str,
+        value: Expr<'src>,
+        span: Span,
+    },
+    /// Computed property constraint: `method() = value`
+    ComputedProperty {
+        name: &'src str,
+        value: Expr<'src>,
+        span: Span,
+    },
+}
+
+impl<'src> HasSpan for StructLitField<'src> {
+    fn span(&self) -> Span {
+        match self {
+            StructLitField::Field { span, .. } => *span,
+            StructLitField::ComputedProperty { span, .. } => *span,
+        }
+    }
+}
+
+// ============================================================================
 // Expression AST with Type-Safe Operator Precedence
 // ============================================================================
 
@@ -228,7 +258,7 @@ pub enum Expr<'src> {
     #[subenum(CmpLhs, CmpRhs, AddLhs, AddRhs, MulLhs, MulRhs, PowLhs, PowRhs, Atom)]
     StructLit {
         name: &'src str,
-        fields: Vec<(&'src str, Expr<'src>)>,
+        fields: Vec<StructLitField<'src>>,
         span: Span,
     },
 

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -95,22 +95,62 @@ pub fn atom<'src>(
                     },
                 }
             }),
-        // Struct literal: StructName { field1: value1, field2: value2, ... }
+        // Struct literal: StructName { field1: value1, method() = value2, ... }
         select! {
             Token::Identifier(t) => (t.name, t.span),
         }
-        .then(
-            select! { Token::Identifier(t) => t.name }
-                .then_ignore(select! { Token::Colon(_) => () })
-                .then(expr.clone())
+        .then({
+            // Field can be:
+            // 1. Regular field: identifier : expr
+            // 2. Computed property: identifier () = expr
+            let field_parser = select! { Token::Identifier(t) => (t.name, t.span) }
+                .then(choice((
+                    // Computed property: identifier() = expr
+                    select! { Token::LeftParen(_) => () }
+                        .ignore_then(select! { Token::RightParen(_) => () })
+                        .ignore_then(select! { Token::Equals(_) => () })
+                        .ignore_then(expr.clone())
+                        .map(|value| (true, value)),
+                    // Regular field: identifier: expr
+                    select! { Token::Colon(_) => () }
+                        .ignore_then(expr.clone())
+                        .map(|value| (false, value)),
+                )))
+                .map_with(|((name, name_span), (is_computed, value)), e| {
+                    use crate::ast::StructLitField;
+                    let span_range = e.span();
+                    if is_computed {
+                        StructLitField::ComputedProperty {
+                            name,
+                            value,
+                            span: Span {
+                                start: name_span.start,
+                                lines: 0,
+                                end_column: span_range.end,
+                            },
+                        }
+                    } else {
+                        StructLitField::Field {
+                            name,
+                            value,
+                            span: Span {
+                                start: name_span.start,
+                                lines: 0,
+                                end_column: span_range.end,
+                            },
+                        }
+                    }
+                });
+
+            field_parser
                 .separated_by(select! { Token::Comma(_) => () })
                 .allow_trailing()
                 .collect::<Vec<_>>()
                 .delimited_by(
                     select! { Token::LeftBrace(_) => () },
                     select! { Token::RightBrace(_) => () },
-                ),
-        )
+                )
+        })
         .map_with(|((name, name_span), fields), e| {
             let span_range = e.span();
             Atom::StructLit {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2947,8 +2947,14 @@ fn test_struct_literal_single_field() {
         Expr::StructLit { name, fields, .. } => {
             assert_eq!(name, "Point");
             assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].0, "x");
-            assert_matches!(fields[0].1, Expr::IntLit { value: 10, .. });
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "x",
+                    value: Expr::IntLit { value: 10, .. },
+                    ..
+                }
+            );
         }
         other => panic!("Expected Expr::StructLit, got {:?}", other),
     }
@@ -2966,10 +2972,22 @@ fn test_struct_literal_multiple_fields() {
         Expr::StructLit { name, fields, .. } => {
             assert_eq!(name, "Point");
             assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].0, "x");
-            assert_eq!(fields[1].0, "y");
-            assert_matches!(fields[0].1, Expr::IntLit { value: 10, .. });
-            assert_matches!(fields[1].1, Expr::IntLit { value: 20, .. });
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "x",
+                    value: Expr::IntLit { value: 10, .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[1],
+                StructLitField::Field {
+                    name: "y",
+                    value: Expr::IntLit { value: 20, .. },
+                    ..
+                }
+            );
         }
         other => panic!("Expected Expr::StructLit, got {:?}", other),
     }
@@ -2987,10 +3005,22 @@ fn test_struct_literal_with_expressions() {
         Expr::StructLit { name, fields, .. } => {
             assert_eq!(name, "Circle");
             assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].0, "center");
-            assert_eq!(fields[1].0, "radius");
-            assert_matches!(fields[0].1, Expr::Call { .. });
-            assert_matches!(fields[1].1, Expr::Mul { .. });
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "center",
+                    value: Expr::Call { .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[1],
+                StructLitField::Field {
+                    name: "radius",
+                    value: Expr::Mul { .. },
+                    ..
+                }
+            );
         }
         other => panic!("Expected Expr::StructLit, got {:?}", other),
     }
@@ -3025,10 +3055,22 @@ fn test_nested_struct_literal() {
         Expr::StructLit { name, fields, .. } => {
             assert_eq!(name, "Line");
             assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].0, "start");
-            assert_eq!(fields[1].0, "end");
-            assert_matches!(fields[0].1, Expr::StructLit { .. });
-            assert_matches!(fields[1].1, Expr::StructLit { .. });
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "start",
+                    value: Expr::StructLit { .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[1],
+                StructLitField::Field {
+                    name: "end",
+                    value: Expr::StructLit { .. },
+                    ..
+                }
+            );
         }
         other => panic!("Expected Expr::StructLit, got {:?}", other),
     }
@@ -3049,6 +3091,105 @@ fn test_array_of_struct_literals() {
             assert_matches!(elements[1], Expr::StructLit { .. });
         }
         other => panic!("Expected Expr::ArrayLit, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_literal_computed_property() {
+    let result = parse_with_timeout(
+        "Rect { area() = 500 }",
+        |input| expr().parse(input).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Expr::StructLit { name, fields, .. } => {
+            assert_eq!(name, "Rect");
+            assert_eq!(fields.len(), 1);
+            assert_matches!(
+                &fields[0],
+                StructLitField::ComputedProperty {
+                    name: "area",
+                    value: Expr::IntLit { value: 500, .. },
+                    ..
+                }
+            );
+        }
+        other => panic!("Expected Expr::StructLit, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_literal_mixed_fields_and_computed() {
+    let result = parse_with_timeout(
+        "Rect { width: 100, area() = 500, height: 50 }",
+        |input| expr().parse(input).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Expr::StructLit { name, fields, .. } => {
+            assert_eq!(name, "Rect");
+            assert_eq!(fields.len(), 3);
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "width",
+                    value: Expr::IntLit { value: 100, .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[1],
+                StructLitField::ComputedProperty {
+                    name: "area",
+                    value: Expr::IntLit { value: 500, .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[2],
+                StructLitField::Field {
+                    name: "height",
+                    value: Expr::IntLit { value: 50, .. },
+                    ..
+                }
+            );
+        }
+        other => panic!("Expected Expr::StructLit, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_struct_literal_computed_property_expression() {
+    let result = parse_with_timeout(
+        "Circle { center: point(0, 0), circumference() = 2 * 3.14 * r }",
+        |input| expr().parse(input).into_result(),
+        Duration::from_secs(2),
+    );
+
+    match result.unwrap() {
+        Expr::StructLit { name, fields, .. } => {
+            assert_eq!(name, "Circle");
+            assert_eq!(fields.len(), 2);
+            assert_matches!(
+                &fields[0],
+                StructLitField::Field {
+                    name: "center",
+                    value: Expr::Call { .. },
+                    ..
+                }
+            );
+            assert_matches!(
+                &fields[1],
+                StructLitField::ComputedProperty {
+                    name: "circumference",
+                    value: Expr::Mul { .. },
+                    ..
+                }
+            );
+        }
+        other => panic!("Expected Expr::StructLit, got {:?}", other),
     }
 }
 


### PR DESCRIPTION
Implements support for computed properties in struct literals following
the TextCAD language specification. Struct literals can now include:
- Regular field assignments: `field: value`
- Computed property constraints: `method() = value`

This enables constraint-based initialization like:
  Rect { width: 100, area() = 500, height: 50 }

Changes:
- Added StructLitField enum to represent both field types
- Updated AST, parser, and display implementations
- Added comprehensive tests for computed properties
- Updated existing tests for new StructLitField type

All quality checks pass (fmt, clippy, tests).