### PR TITLE
Add arena-based HIR infrastructure with bumpalo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,11 +99,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "cad-dsl"
 version = "0.1.0"
 dependencies = [
  "ariadne",
  "assert_matches",
+ "bumpalo",
  "chumsky",
  "clap",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 ariadne = "0.4"
+bumpalo = "3.16"
 chumsky = "0.12.0"
 clap = { version = "4.5.53", features = ["derive"] }
 logos = "0.16.0"

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -1,0 +1,308 @@
+//! High-level Intermediate Representation (HIR)
+//!
+//! The HIR is the semantic representation of a CAD-DSL program after parsing and
+//! name resolution. It serves as the bridge between the Abstract Syntax Tree (AST)
+//! and later compilation stages like type checking and constraint solving.
+//!
+//! # What is HIR?
+//!
+//! The High-level Intermediate Representation (HIR) transforms the syntax-focused
+//! AST into a semantically-enriched representation where:
+//!
+//! - **Names are resolved**: Variables, functions, types, and fields are linked to
+//!   their definitions through direct references rather than just names
+//! - **Scopes are tracked**: Each definition knows its scope level for proper shadowing
+//!   and lookup semantics
+//! - **Types are associated**: Every expression carries its resolved type information
+//! - **Cross-references exist**: Methods know their parent structs, fields know their
+//!   containing types, and expressions reference their definitions
+//!
+//! # Differences from AST
+//!
+//! While the AST is a faithful representation of source syntax, the HIR provides:
+//!
+//! ## 1. Name Resolution
+//!
+//! **AST**: Names are just strings
+//! ```text
+//! Expr::Var { name: "x" }  // Just a string reference
+//! ```
+//!
+//! **HIR**: Names resolve to their definitions
+//! ```text
+//! ResolvedExpr {
+//!     kind: Var {
+//!         name: "x",
+//!         definition: &VarDefinition { ... }  // Direct reference
+//!     }
+//! }
+//! ```
+//!
+//! ## 2. Type Information
+//!
+//! **AST**: Types are syntactic annotations
+//! ```text
+//! Type::Named { name: "Point" }  // Just a name
+//! ```
+//!
+//! **HIR**: Types include full definition information
+//! ```text
+//! ResolvedType::UserDefined {
+//!     name: "Point",
+//!     definition: &StructDefinition { ... }  // Link to struct
+//! }
+//! ```
+//!
+//! ## 3. Scope Tracking
+//!
+//! The HIR tracks scope levels to enable:
+//! - Variable shadowing detection
+//! - Proper lexical scoping rules
+//! - Efficient name lookup (search from innermost to outermost scope)
+//!
+//! ## 4. Structural Simplification
+//!
+//! The AST uses type-level precedence hierarchies (via subenums) to enforce parse
+//! tree correctness. The HIR uses a single flat enum since precedence is already
+//! resolved.
+//!
+//! # Arena Allocation Strategy
+//!
+//! The HIR uses arena allocation via `bumpalo::Bump` for superior performance and
+//! memory management:
+//!
+//! ## Why Arena Allocation?
+//!
+//! ### 1. Performance Benefits
+//!
+//! - **Fast allocation**: Allocating is just bumping a pointer - O(1) with minimal overhead
+//! - **Fast deallocation**: The entire HIR is freed at once when the arena drops
+//! - **No individual frees**: Eliminates per-node deallocation overhead
+//! - **Cache locality**: Related data allocated together is stored nearby in memory,
+//!   improving CPU cache hit rates
+//!
+//! ### 2. Safety Guarantees
+//!
+//! - **Lifetime tracking**: The `'arena` lifetime ensures HIR data can't outlive the arena
+//! - **No use-after-free**: Borrow checker prevents accessing deallocated HIR data
+//! - **No reference cycles**: Arena references are acyclic by construction
+//!
+//! ### 3. Simplicity
+//!
+//! - **Direct references**: Use `&'arena T` instead of `Box<T>` or `Rc<T>`
+//! - **No reference counting**: Eliminates runtime overhead of `Rc`/`Arc`
+//! - **Easier to reason about**: Single ownership model via arena
+//!
+//! ## How It Works
+//!
+//! ```rust,ignore
+//! use bumpalo::Bump;
+//!
+//! // Create an arena for the compilation session
+//! let arena = Bump::new();
+//!
+//! // Allocate HIR nodes in the arena
+//! let var_def = arena.alloc(VarDefinition {
+//!     name: "x",
+//!     var_type: Some(ResolvedType::I32 { span }),
+//!     // ...
+//! });
+//!
+//! // Use arena-allocated references in other nodes
+//! let expr = arena.alloc(ResolvedExpr {
+//!     kind: Var {
+//!         name: "x",
+//!         definition: var_def,  // Reference to arena-allocated data
+//!     },
+//!     // ...
+//! });
+//!
+//! // All HIR data is freed when arena is dropped
+//! ```
+//!
+//! # Lifetime Parameters
+//!
+//! HIR types use two lifetime parameters that serve distinct purposes:
+//!
+//! ## `'src` - Source Code Lifetime
+//!
+//! - Represents the lifetime of the original source code string
+//! - Used for string slices (`&'src str`) that point directly into the source
+//! - Avoids allocating copies of identifiers, keywords, etc.
+//! - Examples: variable names, struct names, field names
+//!
+//! ```rust,ignore
+//! struct VarDefinition<'src, 'arena> {
+//!     name: &'src str,  // Points into original source
+//!     // ...
+//! }
+//! ```
+//!
+//! ## `'arena` - Arena Allocator Lifetime
+//!
+//! - Represents the lifetime of the arena allocator
+//! - Used for references to other HIR nodes (`&'arena T`)
+//! - Ensures HIR nodes can't outlive the arena that allocated them
+//! - Enables safe cross-references between HIR nodes
+//!
+//! ```rust,ignore
+//! struct ResolvedExpr<'src, 'arena> {
+//!     ty: &'arena ResolvedType<'src, 'arena>,  // Arena-allocated type
+//!     // ...
+//! }
+//! ```
+//!
+//! ## Lifetime Relationships
+//!
+//! Typically, `'src` outlives `'arena`:
+//! - Source code is loaded first and kept in memory
+//! - Arena is created for compilation session
+//! - Arena is dropped after compilation (while source remains)
+//!
+//! The borrow checker ensures these lifetimes are used correctly throughout the HIR.
+//!
+//! # Semantic Analysis Phase
+//!
+//! The HIR is built during semantic analysis, which consists of several phases:
+//!
+//! ## 1. Name Resolution
+//!
+//! - Build symbol tables mapping names to definitions
+//! - Resolve variable, function, type, and field references
+//! - Detect duplicate definitions and undefined references
+//! - Handle scoping rules (shadowing, nested scopes)
+//!
+//! ## 2. Type Checking
+//!
+//! - Assign types to all expressions
+//! - Verify type compatibility in operations and assignments
+//! - Check function argument types against parameter types
+//! - Resolve method calls based on receiver types
+//! - Handle type inference where types are not explicitly annotated
+//!
+//! ## 3. Scope Analysis
+//!
+//! - Track scope levels for each definition
+//! - Build scope stacks for nested contexts (functions, blocks, with-statements)
+//! - Validate scope-dependent constructs (e.g., dot-prefix in with-blocks)
+//! - Clean up scope entries when exiting nested scopes
+//!
+//! ## 4. Constraint Analysis
+//!
+//! - Identify constraint expressions in with-blocks
+//! - Resolve transform chains for coordinate transformation
+//! - Link container field accesses to their containing structs
+//! - Prepare constraint system for solver
+//!
+//! # Cross-References Between Nodes
+//!
+//! The HIR enables efficient traversal through direct references:
+//!
+//! ## Expression → Definition
+//!
+//! ```text
+//! ResolvedExpr::Var { definition: &VarDefinition }
+//! ResolvedExpr::FunctionCall { function: &FunctionDefinition }
+//! ResolvedExpr::MethodCall { method: &FunctionDefinition }
+//! ResolvedExpr::FieldAccess { field: &FieldDefinition }
+//! ```
+//!
+//! ## Definition → Type
+//!
+//! ```text
+//! VarDefinition { var_type: ResolvedType }
+//! FieldDefinition { field_type: ResolvedType }
+//! FunctionParam { param_type: ResolvedType }
+//! ```
+//!
+//! ## Type → Definition
+//!
+//! ```text
+//! ResolvedType::UserDefined { definition: &StructDefinition }
+//! ResolvedType::Reference { inner: &ResolvedType }
+//! ```
+//!
+//! ## Method → Struct
+//!
+//! ```text
+//! FunctionDefinition { parent_struct: Option<&StructDefinition> }
+//! ```
+//!
+//! ## With-Context → Container
+//!
+//! ```text
+//! WithContext { container_field: Option<&ContainerField> }
+//! ResolvedExpr::ContainerFieldAccess { with_context: &WithContext }
+//! ```
+//!
+//! These cross-references enable:
+//! - Fast type checking (no hash map lookups)
+//! - Efficient constraint solving (direct access to definitions)
+//! - Better error messages (full context available)
+//! - Simplified compiler passes (no separate symbol tables needed)
+//!
+//! # Module Organization
+//!
+//! The HIR is organized into several submodules:
+//!
+//! - **hir_types**: Type system (`ResolvedType`)
+//! - **hir_definitions**: Definitions (`VarDefinition`, `FunctionDefinition`,
+//!   `StructDefinition`, etc.)
+//! - **hir_expr**: Expressions (`ResolvedExpr`, `ResolvedExprKind`)
+//! - **hir_context**: With-statement contexts (`WithContext`, `TransformMethod`)
+//! - **hir_scope**: Scope management (`Scope`, `ScopeStack`)
+//!
+//! # Example
+//!
+//! ```text
+//! // Source code
+//! struct Point { x: f64, y: f64 }
+//! let p = Point { x: 10.0, y: 20.0 };
+//!
+//! // AST (simplified)
+//! StructDef { name: "Point", fields: [...] }
+//! VarDecl { name: "p", init: StructLit { name: "Point", ... } }
+//!
+//! // HIR (simplified)
+//! StructDefinition { name: "Point", fields: [&FieldDef, &FieldDef] }
+//! VarDefinition {
+//!     name: "p",
+//!     var_type: UserDefined {
+//!         name: "Point",
+//!         definition: &StructDefinition  // Direct link!
+//!     },
+//!     init: &ResolvedExpr {
+//!         kind: StructLit { ... },
+//!         ty: &UserDefined { ... }  // Direct link to type!
+//!     }
+//! }
+//! ```
+
+// Allow dead code for now since HIR is not yet fully integrated
+#![allow(dead_code)]
+
+// ============================================================================
+// Public Re-exports
+// ============================================================================
+//
+// Note: The individual HIR modules (hir_types, hir_definitions, etc.) are
+// declared in main.rs at the crate root level. This module serves as a
+// convenient re-export point for all HIR types.
+
+// Type system
+pub use crate::hir_types::ResolvedType;
+
+// Definitions
+pub use crate::hir_definitions::{
+    ContainerField, FieldDefinition, FunctionDefinition, FunctionParam, StructDefinition,
+    VarDefinition,
+};
+
+// Expressions
+pub use crate::hir_expr::{ResolvedExpr, ResolvedExprKind, ResolvedStructLitField};
+
+// Context tracking
+pub use crate::hir_context::{TransformMethod, WithContext};
+
+// Scope management
+pub use crate::hir_scope::{Scope, ScopeStack};

--- a/src/hir_context.rs
+++ b/src/hir_context.rs
@@ -1,0 +1,221 @@
+//! With-context tracking for the High-level Intermediate Representation (HIR).
+//!
+//! This module provides types for tracking context information in CAD-DSL's `with` statements,
+//! which are used for both transform contexts and container field initialization contexts.
+
+// Allow dead code for now since this module is not yet fully integrated
+#![allow(dead_code)]
+//!
+//! # With-Context Semantics
+//!
+//! CAD-DSL supports two primary uses of `with` statements:
+//!
+//! ## Transform Contexts
+//!
+//! Transform contexts allow implicit transformation of coordinates through a chain of transforms:
+//!
+//! ```cad
+//! with transform {
+//!     // Inside this block, coordinates are implicitly transformed
+//!     point(10, 20)  // Coordinates transformed by the transform object
+//! }
+//! ```
+//!
+//! Transform objects must implement a `__transform__` method that converts coordinates.
+//! Multiple transforms can be chained, with each transform's `__transform__` method called
+//! in sequence.
+//!
+//! ## Container Contexts
+//!
+//! Container contexts provide shorthand syntax for initializing fields of container objects:
+//!
+//! ```cad
+//! with sketch {
+//!     let .field1 = value1;
+//!     let .field2 = value2;
+//! }
+//! ```
+//!
+//! The dot-prefix syntax (`.field`) is only valid inside a `with` statement and refers to
+//! fields of the container expression.
+//!
+//! ## Nested With Statements
+//!
+//! With statements can be nested, creating a stack of contexts:
+//!
+//! ```cad
+//! with transform1 {
+//!     with transform2 {
+//!         // Both transforms apply here, transform1 then transform2
+//!         point(10, 20)
+//!     }
+//! }
+//! ```
+//!
+//! The HIR resolver maintains a stack of `WithContext` objects to track the current
+//! nesting level and available transforms.
+
+use crate::hir_definitions::{ContainerField, FunctionDefinition};
+use crate::hir_expr::ResolvedExpr;
+use crate::hir_types::ResolvedType;
+
+/// A with-context tracks the state of a `with` statement during HIR resolution.
+///
+/// Each `with` statement creates a new context that affects name resolution and
+/// implicit operations within its scope. Contexts can be either:
+/// - Transform contexts: providing implicit coordinate transformation
+/// - Container contexts: enabling dot-prefix field initialization
+///
+/// # Lifetimes
+///
+/// - `'src`: The lifetime of the source code string
+/// - `'arena`: The lifetime of the arena allocator used for HIR nodes
+#[derive(Debug, Clone, PartialEq)]
+pub struct WithContext<'src, 'arena> {
+    /// The expression that follows the `with` keyword.
+    ///
+    /// This is the value that provides the context. For transform contexts,
+    /// this expression must evaluate to a type with transform methods.
+    /// For container contexts, this expression is the container being initialized.
+    pub context_expr: &'arena ResolvedExpr<'src, 'arena>,
+
+    /// If this is a container context, this field holds the container's field information.
+    ///
+    /// When `Some`, dot-prefix field access (`.fieldname`) is allowed within the
+    /// with block, referring to fields of this container.
+    pub container_field: Option<&'arena ContainerField<'src, 'arena>>,
+
+    /// The chain of transform methods available in this context.
+    ///
+    /// Transform methods are collected from the context expression's type.
+    /// When multiple `with` statements are nested, transforms are applied
+    /// in order from outermost to innermost.
+    ///
+    /// Each transform defines an input type and output type, and the chain
+    /// must be compatible (output of one transform matches input of the next).
+    pub transforms: Vec<TransformMethod<'src, 'arena>>,
+}
+
+/// A transform method provides coordinate transformation within a with-context.
+///
+/// Transform methods are special functions (typically named `__transform__`) that
+/// convert values from one coordinate space to another. They enable implicit
+/// transformation of coordinates within `with` blocks.
+///
+/// # Type Compatibility
+///
+/// For a chain of transforms to be valid:
+/// - Each transform's `output_type` must be compatible with the next transform's `input_type`
+/// - The final transform's `output_type` determines what coordinate types can be used
+///   in the with block
+///
+/// # Lifetimes
+///
+/// - `'src`: The lifetime of the source code string
+/// - `'arena`: The lifetime of the arena allocator used for HIR nodes
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransformMethod<'src, 'arena> {
+    /// The function definition for this transform method.
+    ///
+    /// This is typically a `__transform__` method defined on the transform type.
+    /// The function takes input coordinates and returns transformed coordinates.
+    pub function: &'arena FunctionDefinition<'src, 'arena>,
+
+    /// The input type accepted by this transform.
+    ///
+    /// Coordinates or values of this type can be passed to the transform function.
+    /// In a transform chain, this must match the output type of the previous transform.
+    pub input_type: &'arena ResolvedType<'src, 'arena>,
+
+    /// The output type produced by this transform.
+    ///
+    /// The transform function returns values of this type.
+    /// In a transform chain, this must match the input type of the next transform.
+    pub output_type: &'arena ResolvedType<'src, 'arena>,
+}
+
+impl<'src, 'arena> WithContext<'src, 'arena> {
+    /// Creates a new transform context with the given expression and transforms.
+    ///
+    /// # Parameters
+    ///
+    /// - `context_expr`: The expression providing the transform context
+    /// - `transforms`: The chain of transform methods available in this context
+    pub fn new_transform(
+        context_expr: &'arena ResolvedExpr<'src, 'arena>,
+        transforms: Vec<TransformMethod<'src, 'arena>>,
+    ) -> Self {
+        Self {
+            context_expr,
+            container_field: None,
+            transforms,
+        }
+    }
+
+    /// Creates a new container context with the given expression and container field.
+    ///
+    /// # Parameters
+    ///
+    /// - `context_expr`: The expression providing the container context
+    /// - `container_field`: The container field information for dot-prefix access
+    pub fn new_container(
+        context_expr: &'arena ResolvedExpr<'src, 'arena>,
+        container_field: &'arena ContainerField<'src, 'arena>,
+    ) -> Self {
+        Self {
+            context_expr,
+            container_field: Some(container_field),
+            transforms: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if this is a transform context (has transforms).
+    pub fn is_transform_context(&self) -> bool {
+        !self.transforms.is_empty()
+    }
+
+    /// Returns `true` if this is a container context (has a container field).
+    pub fn is_container_context(&self) -> bool {
+        self.container_field.is_some()
+    }
+}
+
+impl<'src, 'arena> TransformMethod<'src, 'arena> {
+    /// Creates a new transform method.
+    ///
+    /// # Parameters
+    ///
+    /// - `function`: The transform function definition
+    /// - `input_type`: The type accepted by this transform
+    /// - `output_type`: The type produced by this transform
+    pub fn new(
+        function: &'arena FunctionDefinition<'src, 'arena>,
+        input_type: &'arena ResolvedType<'src, 'arena>,
+        output_type: &'arena ResolvedType<'src, 'arena>,
+    ) -> Self {
+        Self {
+            function,
+            input_type,
+            output_type,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_context_is_transform() {
+        // This test would require setting up actual HIR types,
+        // which will be implemented when the HIR resolver is built.
+        // For now, we just verify the module compiles.
+    }
+
+    #[test]
+    fn test_with_context_is_container() {
+        // This test would require setting up actual HIR types,
+        // which will be implemented when the HIR resolver is built.
+        // For now, we just verify the module compiles.
+    }
+}

--- a/src/hir_definitions.rs
+++ b/src/hir_definitions.rs
@@ -1,0 +1,761 @@
+//! High-level Intermediate Representation (HIR) definition nodes
+//!
+//! This module defines the core definition types for the HIR, including variables,
+//! functions, structs, and fields. All nodes use arena allocation for efficient
+//! memory management and to enable safe cross-references using lifetimes.
+
+// Allow dead code for now since this module is not yet fully integrated
+#![allow(dead_code)]
+//!
+//! # Arena Allocation
+//!
+//! All HIR nodes are allocated in a `bumpalo::Bump` arena allocator, providing:
+//! - Fast allocation (just bumping a pointer)
+//! - No individual deallocations (arena is freed all at once)
+//! - Safe cross-references using arena lifetimes
+//! - Reduced memory fragmentation
+//!
+//! # Lifetimes
+//!
+//! HIR nodes use two lifetime parameters:
+//! - `'src`: Lifetime of the source text (for string slices from the original source)
+//! - `'arena`: Lifetime of the arena allocator (for references to other HIR nodes)
+//!
+//! # Design Philosophy
+//!
+//! HIR definitions are created during semantic analysis after parsing. Unlike the AST,
+//! which is a direct representation of the source syntax, the HIR:
+//! - Resolves names to their definitions
+//! - Tracks scope levels for proper shadowing and lookup
+//! - Connects related entities (methods to structs, etc.)
+//! - Provides a foundation for type checking and constraint solving
+
+use crate::ast::span::HasSpan;
+use crate::hir_expr::ResolvedExpr;
+use crate::hir_types::ResolvedType;
+use crate::lexer::Span;
+use std::collections::HashMap;
+
+// ============================================================================
+// Type Aliases for HIR References
+// ============================================================================
+
+/// HIR expression reference - points to a resolved expression in the arena
+pub type HirExpr<'src, 'arena> = &'arena ResolvedExpr<'src, 'arena>;
+
+/// HIR type reference - represents a resolved type
+pub type HirType<'src, 'arena> = ResolvedType<'src, 'arena>;
+
+/// HIR statement placeholder - to be defined in hir_stmt module
+/// For now, statements are represented as AST statements
+pub type HirStmt<'src, 'arena> = crate::ast::types::Stmt<'src>;
+
+// ============================================================================
+// Scope Level
+// ============================================================================
+
+/// Scope level for tracking variable shadowing and lookup
+///
+/// The scope level is a simple integer that increases as we enter nested scopes
+/// (function bodies, blocks, loops, etc.). This allows us to:
+/// - Detect variable shadowing (same name at different levels)
+/// - Implement proper lexical scoping rules
+/// - Clean up variables when exiting a scope
+///
+/// # Examples
+///
+/// ```text
+/// // Scope level 0 (global)
+/// let x = 1;
+///
+/// fn foo() {           // Scope level 1 (function body)
+///     let x = 2;       // Shadows the global x
+///     {                // Scope level 2 (block)
+///         let x = 3;   // Shadows the function-level x
+///     }
+/// }
+/// ```
+pub type ScopeLevel = usize;
+
+// ============================================================================
+// Variable Definition
+// ============================================================================
+
+/// Variable definition in the HIR
+///
+/// Represents a variable that has been declared with `let`. Variables can be:
+/// - Uninitialized: declared but not assigned a value
+/// - Initialized: declared with an initial value expression
+/// - Type-annotated: explicitly typed, or type can be inferred
+///
+/// # Examples
+///
+/// ```text
+/// let x: i32 = 42;           // Initialized with type annotation
+/// let y: bool;               // Uninitialized with type annotation
+/// let z = 3.14;              // Initialized with inferred type
+/// let container.field = p;   // Container field (handled differently)
+/// ```
+///
+/// # Scope Tracking
+///
+/// Each variable tracks its `scope_level` to enable proper shadowing and lookup:
+/// - Variables at the same level in the same scope must have unique names
+/// - Variables at different levels can shadow outer variables
+/// - When looking up a variable, we search from innermost to outermost scope
+#[derive(Debug, Clone, PartialEq)]
+pub struct VarDefinition<'src, 'arena> {
+    /// Variable name as it appears in source
+    pub name: &'src str,
+
+    /// Span of the variable name for error reporting
+    pub name_span: Span,
+
+    /// Type of the variable (either explicit or inferred)
+    /// None during initial creation, filled in during type checking
+    pub var_type: Option<HirType<'src, 'arena>>,
+
+    /// Optional initialization expression
+    /// None for uninitialized variables (e.g., `let x: i32;`)
+    pub init: Option<HirExpr<'src, 'arena>>,
+
+    /// Scope level where this variable was defined
+    /// Used for shadowing detection and variable lookup
+    pub scope_level: ScopeLevel,
+
+    /// Full span of the variable definition for error reporting
+    pub span: Span,
+}
+
+impl<'src, 'arena> VarDefinition<'src, 'arena> {
+    /// Create a new variable definition
+    pub fn new(
+        name: &'src str,
+        name_span: Span,
+        var_type: Option<HirType<'src, 'arena>>,
+        init: Option<HirExpr<'src, 'arena>>,
+        scope_level: ScopeLevel,
+        span: Span,
+    ) -> Self {
+        Self {
+            name,
+            name_span,
+            var_type,
+            init,
+            scope_level,
+            span,
+        }
+    }
+
+    /// Check if this variable is initialized
+    pub fn is_initialized(&self) -> bool {
+        self.init.is_some()
+    }
+
+    /// Check if this variable has an explicit type annotation
+    pub fn has_type_annotation(&self) -> bool {
+        self.var_type.is_some()
+    }
+}
+
+impl<'src, 'arena> HasSpan for VarDefinition<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
+// Field Definition
+// ============================================================================
+
+/// Field definition within a struct
+///
+/// Represents a named, typed field in a struct definition. Fields are the
+/// data members of a struct and define its internal state.
+///
+/// # Examples
+///
+/// ```text
+/// struct Point {
+///     x: f64,        // FieldDefinition { name: "x", type: F64 }
+///     y: f64,        // FieldDefinition { name: "y", type: F64 }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldDefinition<'src, 'arena> {
+    /// Field name as it appears in the struct definition
+    pub name: &'src str,
+
+    /// Span of the field name for error reporting
+    pub name_span: Span,
+
+    /// Type of the field
+    pub field_type: HirType<'src, 'arena>,
+
+    /// Full span of the field definition for error reporting
+    pub span: Span,
+
+    /// Phantom data to maintain lifetime parameters consistency
+    _phantom: std::marker::PhantomData<&'arena ()>,
+}
+
+impl<'src, 'arena> FieldDefinition<'src, 'arena> {
+    /// Create a new field definition
+    pub fn new(
+        name: &'src str,
+        name_span: Span,
+        field_type: HirType<'src, 'arena>,
+        span: Span,
+    ) -> Self {
+        Self {
+            name,
+            name_span,
+            field_type,
+            span,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'src, 'arena> HasSpan for FieldDefinition<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
+// Container Field
+// ============================================================================
+
+/// Container field for dynamically storing entities
+///
+/// A container field is a special type of field declared with the `container` keyword
+/// in struct definitions. It provides a namespace for dynamically adding entities
+/// (points, lines, etc.) at runtime without pre-declaring them.
+///
+/// # Purpose
+///
+/// Container fields enable patterns like:
+/// - Collecting sketch entities (points, lines, curves)
+/// - Building up constraint systems incrementally
+/// - Dynamically naming and organizing related objects
+///
+/// # Examples
+///
+/// ```text
+/// struct Sketch {
+///     container entities,    // ContainerField for dynamic entities
+///     origin: Point,
+/// }
+///
+/// // Later, entities can be added:
+/// let sketch = Sketch { origin: point(0, 0) };
+/// let sketch.entities.p1 = point(10, 10);
+/// let sketch.entities.line1 = line(p1, p2);
+/// ```
+///
+/// # Implementation
+///
+/// The container uses a HashMap to store dynamically created entities. Each entity
+/// is stored with its name as the key and a reference to its definition as the value.
+#[derive(Debug, Clone)]
+pub struct ContainerField<'src, 'arena> {
+    /// Container field name
+    pub name: &'src str,
+
+    /// Span of the container field name for error reporting
+    pub name_span: Span,
+
+    /// Map of dynamically added entities
+    /// Key: entity name, Value: reference to the entity's variable definition
+    ///
+    /// This map is populated as entities are added to the container at runtime
+    /// (or during semantic analysis for compile-time declarations).
+    pub entities: HashMap<&'src str, &'arena VarDefinition<'src, 'arena>>,
+
+    /// Full span of the container field declaration
+    pub span: Span,
+}
+
+impl<'src, 'arena> ContainerField<'src, 'arena> {
+    /// Create a new container field
+    pub fn new(name: &'src str, name_span: Span, span: Span) -> Self {
+        Self {
+            name,
+            name_span,
+            entities: HashMap::new(),
+            span,
+        }
+    }
+
+    /// Add an entity to this container
+    ///
+    /// Returns `Some(&old_definition)` if an entity with this name already existed,
+    /// `None` otherwise.
+    pub fn add_entity(
+        &mut self,
+        entity_name: &'src str,
+        definition: &'arena VarDefinition<'src, 'arena>,
+    ) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        self.entities.insert(entity_name, definition)
+    }
+
+    /// Look up an entity by name
+    pub fn get_entity(&self, entity_name: &str) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        self.entities.get(entity_name).copied()
+    }
+
+    /// Check if an entity with the given name exists
+    pub fn has_entity(&self, entity_name: &str) -> bool {
+        self.entities.contains_key(entity_name)
+    }
+
+    /// Get the number of entities in this container
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Iterate over all entities in this container
+    pub fn entities_iter(
+        &self,
+    ) -> impl Iterator<Item = (&'src str, &'arena VarDefinition<'src, 'arena>)> + '_ {
+        self.entities.iter().map(|(k, v)| (*k, *v))
+    }
+}
+
+impl<'src, 'arena> HasSpan for ContainerField<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<'src, 'arena> PartialEq for ContainerField<'src, 'arena> {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare all fields except the HashMap for basic equality
+        // For full equality, we'd need to compare HashMap contents as well
+        self.name == other.name
+            && self.name_span == other.name_span
+            && self.span == other.span
+            && self.entities.len() == other.entities.len()
+            && self.entities.iter().all(|(k, v)| {
+                other
+                    .entities
+                    .get(k)
+                    .map(|ov| std::ptr::eq(*v, *ov))
+                    .unwrap_or(false)
+            })
+    }
+}
+
+// ============================================================================
+// Function Definition
+// ============================================================================
+
+/// Function definition in the HIR
+///
+/// Represents a function that can be:
+/// - A top-level function (standalone)
+/// - A method within a struct (has `parent_struct`)
+///
+/// Functions have parameters, a return type, and a body consisting of statements.
+///
+/// # Examples
+///
+/// ```text
+/// // Top-level function
+/// fn distance(p1: &Point, p2: &Point) -> f64 {
+///     let dx = p2.x - p1.x;
+///     let dy = p2.y - p1.y;
+///     sqrt(dx * dx + dy * dy)
+/// }
+///
+/// // Method within a struct
+/// struct Circle {
+///     center: Point,
+///     radius: f64,
+///
+///     fn area() -> f64 {
+///         3.14159 * self.radius * self.radius
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionDefinition<'src, 'arena> {
+    /// Function name
+    pub name: &'src str,
+
+    /// Span of the function name for error reporting
+    pub name_span: Span,
+
+    /// Function parameters
+    /// Each parameter has a name and type
+    pub params: Vec<FunctionParam<'src, 'arena>>,
+
+    /// Return type of the function
+    pub return_type: HirType<'src, 'arena>,
+
+    /// Function body statements
+    /// The body is a sequence of statements executed when the function is called
+    pub body: Vec<HirStmt<'src, 'arena>>,
+
+    /// Optional reference to the parent struct if this is a method
+    /// None for top-level functions, Some(&struct_def) for methods
+    pub parent_struct: Option<&'arena StructDefinition<'src, 'arena>>,
+
+    /// Full span of the function definition for error reporting
+    pub span: Span,
+}
+
+impl<'src, 'arena> FunctionDefinition<'src, 'arena> {
+    /// Create a new function definition
+    pub fn new(
+        name: &'src str,
+        name_span: Span,
+        params: Vec<FunctionParam<'src, 'arena>>,
+        return_type: HirType<'src, 'arena>,
+        body: Vec<HirStmt<'src, 'arena>>,
+        parent_struct: Option<&'arena StructDefinition<'src, 'arena>>,
+        span: Span,
+    ) -> Self {
+        Self {
+            name,
+            name_span,
+            params,
+            return_type,
+            body,
+            parent_struct,
+            span,
+        }
+    }
+
+    /// Check if this is a method (has a parent struct)
+    pub fn is_method(&self) -> bool {
+        self.parent_struct.is_some()
+    }
+
+    /// Check if this is a top-level function
+    pub fn is_top_level(&self) -> bool {
+        self.parent_struct.is_none()
+    }
+
+    /// Get the number of parameters
+    pub fn param_count(&self) -> usize {
+        self.params.len()
+    }
+}
+
+impl<'src, 'arena> HasSpan for FunctionDefinition<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
+// Function Parameter
+// ============================================================================
+
+/// Function parameter with name and type
+///
+/// Parameters are the inputs to a function, each with a name and type.
+/// Unlike the AST version, this HIR version includes the arena lifetime.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionParam<'src, 'arena> {
+    /// Parameter name
+    pub name: &'src str,
+
+    /// Span of the parameter name for error reporting
+    pub name_span: Span,
+
+    /// Parameter type
+    pub param_type: HirType<'src, 'arena>,
+
+    /// Full span of the parameter for error reporting
+    pub span: Span,
+
+    /// Phantom data to maintain lifetime parameters consistency
+    _phantom: std::marker::PhantomData<&'arena ()>,
+}
+
+impl<'src, 'arena> FunctionParam<'src, 'arena> {
+    /// Create a new function parameter
+    pub fn new(
+        name: &'src str,
+        name_span: Span,
+        param_type: HirType<'src, 'arena>,
+        span: Span,
+    ) -> Self {
+        Self {
+            name,
+            name_span,
+            param_type,
+            span,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'src, 'arena> HasSpan for FunctionParam<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
+// Struct Definition
+// ============================================================================
+
+/// Struct definition in the HIR
+///
+/// Represents a user-defined composite type with:
+/// - Named fields (regular data members)
+/// - Methods (functions associated with the struct)
+/// - Optional container field (for dynamic entity storage)
+///
+/// # Container Fields
+///
+/// Structs can have at most one container field, declared with the `container` keyword.
+/// This field provides a namespace for dynamically adding entities.
+///
+/// # Examples
+///
+/// ```text
+/// // Simple struct with fields
+/// struct Point {
+///     x: f64,
+///     y: f64,
+/// }
+///
+/// // Struct with methods
+/// struct Circle {
+///     center: Point,
+///     radius: f64,
+///
+///     fn area() -> f64 {
+///         3.14159 * self.radius * self.radius
+///     }
+///
+///     fn circumference() -> f64 {
+///         2.0 * 3.14159 * self.radius
+///     }
+/// }
+///
+/// // Struct with container field
+/// struct Sketch {
+///     container entities,
+///     origin: Point,
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructDefinition<'src, 'arena> {
+    /// Struct name
+    pub name: &'src str,
+
+    /// Span of the struct name for error reporting
+    pub name_span: Span,
+
+    /// Regular fields (data members)
+    pub fields: Vec<&'arena FieldDefinition<'src, 'arena>>,
+
+    /// Methods (functions associated with this struct)
+    pub methods: Vec<&'arena FunctionDefinition<'src, 'arena>>,
+
+    /// Optional container field for dynamic entities
+    /// At most one container field is allowed per struct
+    pub container_field: Option<&'arena ContainerField<'src, 'arena>>,
+
+    /// Full span of the struct definition for error reporting
+    pub span: Span,
+}
+
+impl<'src, 'arena> StructDefinition<'src, 'arena> {
+    /// Create a new struct definition
+    pub fn new(
+        name: &'src str,
+        name_span: Span,
+        fields: Vec<&'arena FieldDefinition<'src, 'arena>>,
+        methods: Vec<&'arena FunctionDefinition<'src, 'arena>>,
+        container_field: Option<&'arena ContainerField<'src, 'arena>>,
+        span: Span,
+    ) -> Self {
+        Self {
+            name,
+            name_span,
+            fields,
+            methods,
+            container_field,
+            span,
+        }
+    }
+
+    /// Check if this struct has a container field
+    pub fn has_container(&self) -> bool {
+        self.container_field.is_some()
+    }
+
+    /// Get the number of regular fields
+    pub fn field_count(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Get the number of methods
+    pub fn method_count(&self) -> usize {
+        self.methods.len()
+    }
+
+    /// Look up a field by name
+    pub fn find_field(&self, field_name: &str) -> Option<&'arena FieldDefinition<'src, 'arena>> {
+        self.fields.iter().find(|f| f.name == field_name).copied()
+    }
+
+    /// Look up a method by name
+    pub fn find_method(
+        &self,
+        method_name: &str,
+    ) -> Option<&'arena FunctionDefinition<'src, 'arena>> {
+        self.methods.iter().find(|m| m.name == method_name).copied()
+    }
+
+    /// Check if a field with the given name exists
+    pub fn has_field(&self, field_name: &str) -> bool {
+        self.find_field(field_name).is_some()
+    }
+
+    /// Check if a method with the given name exists
+    pub fn has_method(&self, method_name: &str) -> bool {
+        self.find_method(method_name).is_some()
+    }
+}
+
+impl<'src, 'arena> HasSpan for StructDefinition<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bumpalo::Bump;
+
+    /// Helper to create a dummy span for testing
+    fn dummy_span() -> Span {
+        Span {
+            start: crate::lexer::LineColumn { line: 1, column: 1 },
+            lines: 0,
+            end_column: 1,
+        }
+    }
+
+    /// Helper to create a dummy type for testing
+    fn dummy_type<'src, 'arena>() -> HirType<'src, 'arena> {
+        ResolvedType::I32 { span: dummy_span() }
+    }
+
+    #[test]
+    fn test_var_definition_uninitialized() {
+        let var_def = VarDefinition::<'_, '_>::new(
+            "x",
+            dummy_span(),
+            Some(dummy_type()),
+            None,
+            0,
+            dummy_span(),
+        );
+
+        assert_eq!(var_def.name, "x");
+        assert!(!var_def.is_initialized());
+        assert!(var_def.has_type_annotation());
+        assert_eq!(var_def.scope_level, 0);
+    }
+
+    #[test]
+    fn test_container_field_operations() {
+        let arena = Bump::new();
+        let mut container = ContainerField::new("entities", dummy_span(), dummy_span());
+
+        assert_eq!(container.name, "entities");
+        assert_eq!(container.entity_count(), 0);
+        assert!(!container.has_entity("p1"));
+
+        let var_def = arena.alloc(VarDefinition::new(
+            "p1",
+            dummy_span(),
+            Some(dummy_type()),
+            None,
+            0,
+            dummy_span(),
+        ));
+
+        let old = container.add_entity("p1", var_def);
+        assert!(old.is_none());
+        assert_eq!(container.entity_count(), 1);
+        assert!(container.has_entity("p1"));
+
+        let found = container.get_entity("p1");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "p1");
+    }
+
+    #[test]
+    fn test_struct_definition_lookups() {
+        let arena = Bump::new();
+
+        let field1 = arena.alloc(FieldDefinition::new(
+            "x",
+            dummy_span(),
+            dummy_type(),
+            dummy_span(),
+        ));
+
+        let field2 = arena.alloc(FieldDefinition::new(
+            "y",
+            dummy_span(),
+            dummy_type(),
+            dummy_span(),
+        ));
+
+        let struct_def = StructDefinition::new(
+            "Point",
+            dummy_span(),
+            vec![field1, field2],
+            vec![],
+            None,
+            dummy_span(),
+        );
+
+        assert_eq!(struct_def.name, "Point");
+        assert_eq!(struct_def.field_count(), 2);
+        assert_eq!(struct_def.method_count(), 0);
+        assert!(!struct_def.has_container());
+
+        assert!(struct_def.has_field("x"));
+        assert!(struct_def.has_field("y"));
+        assert!(!struct_def.has_field("z"));
+
+        let found_x = struct_def.find_field("x");
+        assert!(found_x.is_some());
+        assert_eq!(found_x.unwrap().name, "x");
+    }
+
+    #[test]
+    fn test_function_definition_method_check() {
+        let func_def = FunctionDefinition::<'_, '_>::new(
+            "distance",
+            dummy_span(),
+            vec![],
+            dummy_type(),
+            vec![],
+            None,
+            dummy_span(),
+        );
+
+        assert_eq!(func_def.name, "distance");
+        assert!(func_def.is_top_level());
+        assert!(!func_def.is_method());
+        assert_eq!(func_def.param_count(), 0);
+    }
+}

--- a/src/hir_expr.rs
+++ b/src/hir_expr.rs
@@ -1,0 +1,376 @@
+//! High-Level Intermediate Representation (HIR) - Resolved Expressions
+//!
+//! This module defines the resolved expression types for the HIR, which differ from
+//! the AST in several key ways:
+
+// Allow dead code for now since this module is not yet fully integrated
+#![allow(dead_code)]
+//!
+//! # Differences from AST
+//!
+//! 1. **Type Resolution**: Every expression has an associated type (`Type<'src, 'arena>`),
+//!    determined during semantic analysis.
+//!
+//! 2. **Name Resolution**: Variables, functions, methods, and fields are linked to their
+//!    definitions via arena-allocated references:
+//!    - `Var` contains `&'arena VarDefinition`
+//!    - `FunctionCall` contains `&'arena FunctionDefinition`
+//!    - `MethodCall` contains `&'arena FunctionDefinition`
+//!    - `FieldAccess` contains `&'arena FieldDefinition`
+//!
+//! 3. **Context Resolution**: `ContainerFieldAccess` (dot-prefixed field access in `with`
+//!    blocks) contains a reference to the `WithContext` it resolves to.
+//!
+//! 4. **Arena Allocation**: All cross-references use arena-allocated pointers (`&'arena`)
+//!    instead of owned allocations (`Box`). This allows the entire HIR to be allocated
+//!    in a single arena and deallocated together, avoiding fragmented heap allocations.
+//!
+//! 5. **No Precedence Hierarchy**: Unlike the AST which uses subenums to enforce operator
+//!    precedence at the type level, the HIR uses a single `ResolvedExprKind` enum since
+//!    precedence has already been handled by the parser.
+//!
+//! # Memory Management
+//!
+//! The HIR uses `bumpalo::Bump` as an arena allocator:
+//! - All resolved expressions are allocated in the arena
+//! - Cross-references between HIR nodes use `&'arena` pointers
+//! - The entire HIR is deallocated when the arena is dropped
+//! - This is faster than individual heap allocations and provides better cache locality
+//!
+//! # Lifetimes
+//!
+//! - `'src`: Lifetime of the source code string (for string slices)
+//! - `'arena`: Lifetime of the arena allocator (for HIR node references)
+
+use crate::ast::HasSpan;
+use crate::hir_context::WithContext;
+use crate::hir_definitions::{FieldDefinition, FunctionDefinition, VarDefinition};
+use crate::hir_types::ResolvedType;
+use crate::lexer::Span;
+
+// ============================================================================
+// Resolved Expression Types
+// ============================================================================
+
+/// A resolved expression in the HIR with type and span information
+///
+/// Every expression in the HIR has:
+/// - A span for error reporting
+/// - A kind (the actual expression variant)
+/// - A type (resolved during semantic analysis)
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedExpr<'src, 'arena> {
+    /// Source location for error reporting
+    pub span: Span,
+
+    /// The kind of expression
+    pub kind: ResolvedExprKind<'src, 'arena>,
+
+    /// The resolved type of this expression
+    pub ty: &'arena ResolvedType<'src, 'arena>,
+}
+
+impl<'src, 'arena> HasSpan for ResolvedExpr<'src, 'arena> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+/// The kind of a resolved expression
+///
+/// Unlike the AST, this is a single flat enum without precedence hierarchies,
+/// since operator precedence has already been handled during parsing.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedExprKind<'src, 'arena> {
+    // ========================================================================
+    // Variables and References
+    // ========================================================================
+    /// Variable reference - resolved to its definition
+    Var {
+        /// The variable name (from source)
+        name: &'src str,
+        /// Reference to the variable's definition
+        definition: &'arena VarDefinition<'src, 'arena>,
+    },
+
+    // ========================================================================
+    // Function and Method Calls
+    // ========================================================================
+    /// Function call - resolved to function definition
+    FunctionCall {
+        /// The function name (from source)
+        name: &'src str,
+        /// Reference to the function's definition
+        function: &'arena FunctionDefinition<'src, 'arena>,
+        /// Resolved argument expressions
+        args: Vec<&'arena ResolvedExpr<'src, 'arena>>,
+    },
+
+    /// Method call - resolved to method definition
+    MethodCall {
+        /// The receiver expression (what the method is called on)
+        receiver: &'arena ResolvedExpr<'src, 'arena>,
+        /// The method name (from source)
+        method_name: &'src str,
+        /// Reference to the method's definition
+        method: &'arena FunctionDefinition<'src, 'arena>,
+        /// Resolved argument expressions
+        args: Vec<&'arena ResolvedExpr<'src, 'arena>>,
+    },
+
+    // ========================================================================
+    // Field Access
+    // ========================================================================
+    /// Field access - resolved to field definition
+    FieldAccess {
+        /// The receiver expression (struct/object being accessed)
+        receiver: &'arena ResolvedExpr<'src, 'arena>,
+        /// The field name (from source)
+        field_name: &'src str,
+        /// Reference to the field's definition
+        field: &'arena FieldDefinition<'src, 'arena>,
+    },
+
+    /// Container field access (dot-prefixed in `with` blocks)
+    ///
+    /// Example: `.field` or `.field.x` within a `with` block
+    /// This resolves to fields on the container being constrained.
+    ContainerFieldAccess {
+        /// Resolved path to the field
+        /// For `.field` -> vec!["field"]
+        /// For `.field.x` -> vec!["field", "x"]
+        resolved_path: Vec<&'src str>,
+        /// Reference to the `with` context this access resolves to
+        with_context: &'arena WithContext<'src, 'arena>,
+        /// Optional transform applied to the container
+        /// (e.g., for accessing transformed geometry)
+        transform: Option<&'arena ResolvedExpr<'src, 'arena>>,
+    },
+
+    // ========================================================================
+    // Binary Operations
+    // ========================================================================
+    /// Logical AND: `lhs && rhs`
+    And {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Logical OR: `lhs || rhs`
+    Or {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Equality: `lhs == rhs`
+    Eq {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Not equal: `lhs != rhs`
+    NotEq {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Less than: `lhs < rhs`
+    Lt {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Greater than: `lhs > rhs`
+    Gt {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Less than or equal: `lhs <= rhs`
+    LtEq {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Greater than or equal: `lhs >= rhs`
+    GtEq {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Addition: `lhs + rhs`
+    Add {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Subtraction: `lhs - rhs`
+    Sub {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Multiplication: `lhs * rhs`
+    Mul {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Division: `lhs / rhs`
+    Div {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Modulo: `lhs % rhs`
+    Mod {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Power: `lhs ^ rhs`
+    Pow {
+        lhs: &'arena ResolvedExpr<'src, 'arena>,
+        rhs: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    // ========================================================================
+    // Unary Operations
+    // ========================================================================
+    /// Unary negation: `-expr`
+    Neg {
+        inner: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Unary reference: `&expr`
+    /// Used for creating references in the constraint system
+    Ref {
+        inner: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    // ========================================================================
+    // Literals
+    // ========================================================================
+    /// Integer literal
+    IntLit { value: i32 },
+
+    /// Floating-point literal
+    FloatLit { value: f64 },
+
+    /// Boolean literal
+    BoolLit { value: bool },
+
+    // ========================================================================
+    // Composite Expressions
+    // ========================================================================
+    /// Struct literal with resolved field assignments
+    StructLit {
+        /// The struct type name
+        name: &'src str,
+        /// Resolved field assignments
+        fields: Vec<ResolvedStructLitField<'src, 'arena>>,
+    },
+
+    /// Array literal
+    ArrayLit {
+        /// Resolved element expressions
+        elements: Vec<&'arena ResolvedExpr<'src, 'arena>>,
+    },
+
+    /// Array indexing: `array[index]`
+    Index {
+        /// The array being indexed
+        array: &'arena ResolvedExpr<'src, 'arena>,
+        /// The index expression
+        index: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Range expression: `start..end`
+    Range {
+        /// Start of the range
+        start: &'arena ResolvedExpr<'src, 'arena>,
+        /// End of the range
+        end: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Closure expression: `|params| body`
+    Closure {
+        /// Parameter names
+        params: Vec<&'src str>,
+        /// Resolved body expression
+        body: &'arena ResolvedExpr<'src, 'arena>,
+    },
+
+    /// Parenthesized expression: `(expr)`
+    /// Kept in HIR for source fidelity and error reporting
+    Paren {
+        inner: &'arena ResolvedExpr<'src, 'arena>,
+    },
+}
+
+// ============================================================================
+// Struct Literal Field
+// ============================================================================
+
+/// A resolved field in a struct literal
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedStructLitField<'src, 'arena> {
+    /// Regular field assignment: `field: value`
+    Field {
+        /// Field name
+        name: &'src str,
+        /// Resolved value expression
+        value: &'arena ResolvedExpr<'src, 'arena>,
+        /// Reference to the field definition
+        field_def: &'arena FieldDefinition<'src, 'arena>,
+        /// Span for error reporting
+        span: Span,
+    },
+
+    /// Computed property constraint: `method() = value`
+    /// Used for constraint-based property assignment
+    ComputedProperty {
+        /// Method name
+        name: &'src str,
+        /// Resolved value expression
+        value: &'arena ResolvedExpr<'src, 'arena>,
+        /// Reference to the method definition
+        method_def: &'arena FunctionDefinition<'src, 'arena>,
+        /// Span for error reporting
+        span: Span,
+    },
+}
+
+impl<'src, 'arena> HasSpan for ResolvedStructLitField<'src, 'arena> {
+    fn span(&self) -> Span {
+        match self {
+            ResolvedStructLitField::Field { span, .. } => *span,
+            ResolvedStructLitField::ComputedProperty { span, .. } => *span,
+        }
+    }
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+impl<'src, 'arena> ResolvedExpr<'src, 'arena> {
+    /// Create a new resolved expression
+    pub fn new(
+        span: Span,
+        kind: ResolvedExprKind<'src, 'arena>,
+        ty: &'arena ResolvedType<'src, 'arena>,
+    ) -> Self {
+        Self { span, kind, ty }
+    }
+
+    /// Get the type of this expression
+    pub fn ty(&self) -> &'arena ResolvedType<'src, 'arena> {
+        self.ty
+    }
+
+    /// Get the kind of this expression
+    pub fn kind(&self) -> &ResolvedExprKind<'src, 'arena> {
+        &self.kind
+    }
+}

--- a/src/hir_scope.rs
+++ b/src/hir_scope.rs
@@ -1,0 +1,843 @@
+//! Symbol table and scope management for the High-level Intermediate Representation (HIR).
+//!
+//! This module provides the infrastructure for tracking variables, scopes, and context
+//! information during semantic analysis of CAD-DSL programs. It uses arena allocation
+//! for efficient memory management and safe cross-references.
+
+// Allow dead code for now since this module is not yet fully integrated
+#![allow(dead_code)]
+//!
+//! # Scope Management Overview
+//!
+//! The scope system implements lexical scoping with support for:
+//! - **Nested scopes**: Blocks, functions, and with-statements create new scopes
+//! - **Variable shadowing**: Inner scopes can shadow variables from outer scopes
+//! - **With-contexts**: Special scoping for transform and container contexts
+//! - **Forward references**: CAD-DSL allows referencing variables before declaration
+//!
+//! # Lexical Scoping Rules
+//!
+//! CAD-DSL follows standard lexical scoping rules:
+//!
+//! 1. **Variables are visible from declaration point to end of scope**
+//!    ```cad
+//!    {
+//!        // x not visible here
+//!        let x = 10;
+//!        // x visible here
+//!    }
+//!    // x not visible here
+//!    ```
+//!
+//! 2. **Inner scopes can access outer scope variables**
+//!    ```cad
+//!    let x = 10;
+//!    {
+//!        let y = x + 5;  // Can access x from outer scope
+//!    }
+//!    ```
+//!
+//! 3. **Inner scopes can shadow outer scope variables**
+//!    ```cad
+//!    let x = 10;
+//!    {
+//!        let x = 20;     // Shadows outer x
+//!        // x is 20 here
+//!    }
+//!    // x is 10 here
+//!    ```
+//!
+//! # Variable Shadowing
+//!
+//! When a variable is declared with the same name as a variable in an outer scope,
+//! the inner variable shadows (hides) the outer one within its scope:
+//!
+//! ```cad
+//! let x = 1;              // Scope level 0
+//! fn foo() {              // Scope level 1
+//!     let x = 2;          // Shadows level 0's x
+//!     {                   // Scope level 2
+//!         let x = 3;      // Shadows level 1's x
+//!         // x is 3 here
+//!     }
+//!     // x is 2 here
+//! }
+//! // x is 1 here
+//! ```
+//!
+//! The scope stack searches from innermost to outermost scope, so the most recently
+//! declared variable with a given name is found first.
+//!
+//! # With-Context Scoping
+//!
+//! With-statements create special scopes that affect name resolution in two ways:
+//!
+//! ## 1. Container Field Access with Dot-Prefix
+//!
+//! Inside a with-statement with a container context, the dot-prefix syntax (`.field`)
+//! provides shorthand access to container fields:
+//!
+//! ```cad
+//! with sketch {
+//!     let .p1 = point(0, 0);      // Equivalent to: let sketch.p1 = point(0, 0);
+//!     let .p2 = point(10, 10);    // Equivalent to: let sketch.p2 = point(10, 10);
+//! }
+//! ```
+//!
+//! The scope stack tracks the current with-context and resolves dot-prefix names
+//! to the container expression.
+//!
+//! ## 2. Transform Contexts
+//!
+//! Transform contexts apply implicit transformations to coordinates:
+//!
+//! ```cad
+//! with transform1 {
+//!     with transform2 {
+//!         // Coordinates are implicitly transformed through both transforms
+//!         point(10, 20)  // Passed through transform1 then transform2
+//!     }
+//! }
+//! ```
+//!
+//! The scope stack maintains a chain of with-contexts to enable proper transform
+//! composition.
+//!
+//! # Forward References
+//!
+//! **IMPORTANT**: CAD-DSL allows forward references within the same scope for certain
+//! declarations (particularly in constraint contexts):
+//!
+//! ```cad
+//! {
+//!     constraint distance(p1, p2) == 10;  // References p1 and p2 before declaration
+//!     let p1 = point(0, 0);
+//!     let p2 = point(10, 0);
+//! }
+//! ```
+//!
+//! To support forward references:
+//!
+//! 1. **Two-pass resolution**: The semantic analyzer makes multiple passes:
+//!    - First pass: Collect all declarations in a scope
+//!    - Second pass: Resolve expressions and type-check
+//!
+//! 2. **Uninitialized variables**: Variables can be declared without initialization
+//!    and initialized later (or left uninitialized for solver-assigned values)
+//!
+//! 3. **Constraint ordering**: Constraints are collected and solved as a system,
+//!    not evaluated sequentially
+//!
+//! The scope stack supports forward references by allowing variable lookup before
+//! the variable's initialization expression is processed.
+//!
+//! # Arena Allocation
+//!
+//! All scope-related data uses arena allocation (`bumpalo::Bump`):
+//! - Variable definitions are allocated in the arena
+//! - With-contexts are allocated in the arena
+//! - References use arena lifetimes for safety
+//!
+//! This design enables:
+//! - Fast allocation (pointer bumping)
+//! - Safe cross-references without reference counting
+//! - Automatic cleanup when analysis completes
+
+use crate::hir_context::WithContext;
+use crate::hir_definitions::VarDefinition;
+use std::collections::HashMap;
+
+// ============================================================================
+// Scope
+// ============================================================================
+
+/// A single scope level in the scope stack.
+///
+/// A scope represents a lexical scope boundary (function body, block, with-statement, etc.)
+/// and tracks:
+/// - Variables declared in this scope
+/// - The current with-context (if inside a with-statement)
+/// - The nesting level for debugging and error messages
+///
+/// # Lifetimes
+///
+/// - `'src`: Lifetime of the source text (for variable names)
+/// - `'arena`: Lifetime of the arena allocator (for variable definitions and contexts)
+#[derive(Debug)]
+pub struct Scope<'src, 'arena> {
+    /// Variables declared in this scope.
+    ///
+    /// Maps variable names to their definitions. Only variables declared directly
+    /// in this scope are stored here; variables from outer scopes are not included.
+    ///
+    /// When looking up a variable, we search scopes from innermost to outermost,
+    /// so the first match found is the correct one (implementing shadowing).
+    pub variables: HashMap<&'src str, &'arena VarDefinition<'src, 'arena>>,
+
+    /// Optional with-context active in this scope.
+    ///
+    /// When a with-statement is entered, a new scope is created with a with-context.
+    /// This context affects name resolution for:
+    /// - Dot-prefix field access (`.fieldname`)
+    /// - Implicit coordinate transformations
+    ///
+    /// The with-context is `None` for regular scopes (functions, blocks) and `Some`
+    /// for scopes created by with-statements.
+    pub with_context: Option<&'arena WithContext<'src, 'arena>>,
+
+    /// The nesting level of this scope.
+    ///
+    /// Scope levels start at 0 (global scope) and increase as we enter nested scopes:
+    /// - 0: Global/module scope
+    /// - 1: Function bodies, top-level blocks
+    /// - 2+: Nested blocks, with-statements, etc.
+    ///
+    /// This is used for:
+    /// - Debugging and error messages
+    /// - Tracking variable shadowing
+    /// - Determining scope boundaries
+    pub scope_level: usize,
+}
+
+impl<'src, 'arena> Scope<'src, 'arena> {
+    /// Creates a new scope at the given nesting level.
+    ///
+    /// # Parameters
+    ///
+    /// - `scope_level`: The nesting level for this scope (0 for global, 1+ for nested)
+    pub fn new(scope_level: usize) -> Self {
+        Self {
+            variables: HashMap::new(),
+            with_context: None,
+            scope_level,
+        }
+    }
+
+    /// Creates a new scope with a with-context.
+    ///
+    /// This is used when entering a with-statement to create a scope that tracks
+    /// the context expression and enables special name resolution rules.
+    ///
+    /// # Parameters
+    ///
+    /// - `scope_level`: The nesting level for this scope
+    /// - `with_context`: The with-context information for this scope
+    pub fn new_with_context(
+        scope_level: usize,
+        with_context: &'arena WithContext<'src, 'arena>,
+    ) -> Self {
+        Self {
+            variables: HashMap::new(),
+            with_context: Some(with_context),
+            scope_level,
+        }
+    }
+
+    /// Declares a new variable in this scope.
+    ///
+    /// If a variable with the same name already exists in this scope, returns
+    /// `Some(&old_definition)` for error reporting. If the variable is new,
+    /// returns `None`.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The variable name
+    /// - `definition`: The variable definition (allocated in the arena)
+    ///
+    /// # Returns
+    ///
+    /// - `None` if the variable is new in this scope
+    /// - `Some(&old_definition)` if a variable with this name already exists in this scope
+    pub fn declare_variable(
+        &mut self,
+        name: &'src str,
+        definition: &'arena VarDefinition<'src, 'arena>,
+    ) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        self.variables.insert(name, definition)
+    }
+
+    /// Looks up a variable by name in this scope only.
+    ///
+    /// Does not search outer scopes; use `ScopeStack::lookup_variable()` for
+    /// full lexical scope lookup.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The variable name to look up
+    ///
+    /// # Returns
+    ///
+    /// - `Some(&definition)` if the variable is declared in this scope
+    /// - `None` if the variable is not in this scope
+    pub fn lookup_variable(&self, name: &str) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        self.variables.get(name).copied()
+    }
+
+    /// Returns the number of variables declared in this scope.
+    pub fn variable_count(&self) -> usize {
+        self.variables.len()
+    }
+
+    /// Returns true if this scope has a with-context.
+    pub fn has_with_context(&self) -> bool {
+        self.with_context.is_some()
+    }
+
+    /// Returns true if this is a container context (with-context with a container field).
+    pub fn is_container_context(&self) -> bool {
+        self.with_context
+            .map(|ctx| ctx.is_container_context())
+            .unwrap_or(false)
+    }
+
+    /// Returns true if this is a transform context (with-context with transforms).
+    pub fn is_transform_context(&self) -> bool {
+        self.with_context
+            .map(|ctx| ctx.is_transform_context())
+            .unwrap_or(false)
+    }
+}
+
+// ============================================================================
+// ScopeStack
+// ============================================================================
+
+/// A stack of scopes for lexical scope management.
+///
+/// The scope stack tracks the current nesting of scopes during semantic analysis.
+/// As we enter new scopes (functions, blocks, with-statements), we push a new scope
+/// onto the stack. As we exit scopes, we pop from the stack.
+///
+/// # Lexical Lookup
+///
+/// When looking up a variable, we search from the innermost scope (top of stack)
+/// to the outermost scope (bottom of stack). The first match found is returned,
+/// implementing proper shadowing semantics.
+///
+/// # With-Context Tracking
+///
+/// The stack maintains the current with-context by searching for the innermost
+/// scope that has a with-context. This enables proper resolution of:
+/// - Dot-prefix field access (`.field`)
+/// - Nested transform contexts
+///
+/// # Lifetimes
+///
+/// - `'src`: Lifetime of the source text (for variable names)
+/// - `'arena`: Lifetime of the arena allocator (for definitions and contexts)
+#[derive(Debug)]
+pub struct ScopeStack<'src, 'arena> {
+    /// The stack of scopes, from outermost (index 0) to innermost (last index).
+    ///
+    /// The global scope is typically at index 0, and nested scopes are pushed onto the end.
+    /// We maintain the invariant that this stack is never empty during analysis
+    /// (there is always at least a global scope).
+    scopes: Vec<Scope<'src, 'arena>>,
+}
+
+impl<'src, 'arena> ScopeStack<'src, 'arena> {
+    /// Creates a new scope stack with a global scope at level 0.
+    ///
+    /// The stack always starts with at least one scope (the global scope).
+    pub fn new() -> Self {
+        Self {
+            scopes: vec![Scope::new(0)],
+        }
+    }
+
+    /// Pushes a new scope onto the stack.
+    ///
+    /// The new scope's level is one greater than the current scope's level.
+    /// After pushing, the new scope becomes the current scope.
+    pub fn push_scope(&mut self) {
+        let new_level = self.current_scope_level() + 1;
+        self.scopes.push(Scope::new(new_level));
+    }
+
+    /// Pops the current scope from the stack.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is only one scope (the global scope) remaining, as we must
+    /// maintain the invariant that the stack is never empty.
+    ///
+    /// # Returns
+    ///
+    /// The popped scope, which can be used for cleanup or error reporting.
+    pub fn pop_scope(&mut self) -> Scope<'src, 'arena> {
+        assert!(
+            self.scopes.len() > 1,
+            "Cannot pop the global scope; scope stack must never be empty"
+        );
+        self.scopes
+            .pop()
+            .expect("Checked that scopes has more than 1 element")
+    }
+
+    /// Enters a with-context by pushing a new scope with the given context.
+    ///
+    /// This is used when entering a with-statement. The new scope will have a
+    /// with-context attached, enabling special name resolution rules.
+    ///
+    /// # Parameters
+    ///
+    /// - `with_context`: The with-context information for this scope
+    pub fn enter_with_context(&mut self, with_context: &'arena WithContext<'src, 'arena>) {
+        let new_level = self.current_scope_level() + 1;
+        self.scopes
+            .push(Scope::new_with_context(new_level, with_context));
+    }
+
+    /// Exits the current with-context by popping the scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - There is only the global scope remaining
+    /// - The current scope does not have a with-context
+    ///
+    /// # Returns
+    ///
+    /// The popped scope with its with-context.
+    pub fn exit_with_context(&mut self) -> Scope<'src, 'arena> {
+        assert!(
+            self.scopes.len() > 1,
+            "Cannot pop the global scope; scope stack must never be empty"
+        );
+        let scope = self.scopes.pop().expect("Checked scopes is not empty");
+        assert!(
+            scope.has_with_context(),
+            "exit_with_context called but current scope has no with-context"
+        );
+        scope
+    }
+
+    /// Looks up a variable by name, searching from innermost to outermost scope.
+    ///
+    /// This implements proper lexical scoping with shadowing: the first variable
+    /// found (starting from the innermost scope) is returned.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The variable name to look up
+    ///
+    /// # Returns
+    ///
+    /// - `Some(&definition)` if the variable is found in any scope
+    /// - `None` if the variable is not declared in any scope
+    pub fn lookup_variable(&self, name: &str) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        // Search from innermost (end of vec) to outermost (start of vec)
+        for scope in self.scopes.iter().rev() {
+            if let Some(var_def) = scope.lookup_variable(name) {
+                return Some(var_def);
+            }
+        }
+        None
+    }
+
+    /// Declares a new variable in the current scope.
+    ///
+    /// If a variable with the same name already exists in the current scope
+    /// (but not in outer scopes), returns `Some(&old_definition)` for error reporting.
+    ///
+    /// Note: Variables in outer scopes can be shadowed; this only returns an error
+    /// if the variable is redeclared in the *same* scope.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The variable name
+    /// - `definition`: The variable definition (allocated in the arena)
+    ///
+    /// # Returns
+    ///
+    /// - `None` if the variable is successfully declared (new in current scope)
+    /// - `Some(&old_definition)` if a variable with this name already exists in the current scope
+    pub fn declare_variable(
+        &mut self,
+        name: &'src str,
+        definition: &'arena VarDefinition<'src, 'arena>,
+    ) -> Option<&'arena VarDefinition<'src, 'arena>> {
+        self.current_scope_mut().declare_variable(name, definition)
+    }
+
+    /// Returns the innermost with-context, if any.
+    ///
+    /// Searches from the innermost scope to the outermost scope and returns the
+    /// first with-context found. This is used for:
+    /// - Resolving dot-prefix field access (`.field`)
+    /// - Determining the current transform chain
+    ///
+    /// # Returns
+    ///
+    /// - `Some(&with_context)` if we are inside a with-statement
+    /// - `None` if there is no active with-context
+    pub fn current_with_context(&self) -> Option<&'arena WithContext<'src, 'arena>> {
+        // Search from innermost (end of vec) to outermost (start of vec)
+        for scope in self.scopes.iter().rev() {
+            if let Some(ctx) = scope.with_context {
+                return Some(ctx);
+            }
+        }
+        None
+    }
+
+    /// Returns the current scope level (nesting depth).
+    ///
+    /// The global scope is level 0, and nested scopes have increasing levels.
+    ///
+    /// # Returns
+    ///
+    /// The scope level of the current (innermost) scope.
+    pub fn current_scope_level(&self) -> usize {
+        self.current_scope().scope_level
+    }
+
+    /// Returns the current (innermost) scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scope stack is empty (should never happen as we maintain
+    /// the invariant that at least the global scope exists).
+    fn current_scope(&self) -> &Scope<'src, 'arena> {
+        self.scopes
+            .last()
+            .expect("Scope stack should never be empty")
+    }
+
+    /// Returns a mutable reference to the current (innermost) scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scope stack is empty (should never happen as we maintain
+    /// the invariant that at least the global scope exists).
+    fn current_scope_mut(&mut self) -> &mut Scope<'src, 'arena> {
+        self.scopes
+            .last_mut()
+            .expect("Scope stack should never be empty")
+    }
+
+    /// Returns the total number of scopes in the stack.
+    ///
+    /// This is primarily useful for debugging and testing. The count will always
+    /// be at least 1 (the global scope).
+    pub fn scope_count(&self) -> usize {
+        self.scopes.len()
+    }
+
+    /// Returns true if we are currently inside a with-context.
+    pub fn in_with_context(&self) -> bool {
+        self.current_with_context().is_some()
+    }
+
+    /// Returns true if the current with-context (if any) is a container context.
+    ///
+    /// This is used to determine if dot-prefix syntax is allowed.
+    pub fn in_container_context(&self) -> bool {
+        self.current_with_context()
+            .map(|ctx| ctx.is_container_context())
+            .unwrap_or(false)
+    }
+
+    /// Returns true if the current with-context (if any) is a transform context.
+    pub fn in_transform_context(&self) -> bool {
+        self.current_with_context()
+            .map(|ctx| ctx.is_transform_context())
+            .unwrap_or(false)
+    }
+}
+
+impl<'src, 'arena> Default for ScopeStack<'src, 'arena> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::{LineColumn, Span};
+    use bumpalo::Bump;
+
+    /// Helper to create a dummy span for testing
+    fn dummy_span() -> Span {
+        Span {
+            start: LineColumn { line: 1, column: 1 },
+            lines: 0,
+            end_column: 1,
+        }
+    }
+
+    #[test]
+    fn test_scope_new() {
+        let scope: Scope = Scope::new(0);
+        assert_eq!(scope.scope_level, 0);
+        assert_eq!(scope.variable_count(), 0);
+        assert!(!scope.has_with_context());
+    }
+
+    #[test]
+    fn test_scope_declare_and_lookup() {
+        let arena = Bump::new();
+        let mut scope = Scope::new(0);
+
+        let var_def = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            0,
+            dummy_span(),
+        ));
+
+        // First declaration should succeed
+        assert!(scope.declare_variable("x", var_def).is_none());
+        assert_eq!(scope.variable_count(), 1);
+
+        // Lookup should find the variable
+        let found = scope.lookup_variable("x");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "x");
+
+        // Redeclaring in same scope should return the old definition
+        let var_def2 = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            0,
+            dummy_span(),
+        ));
+        let old = scope.declare_variable("x", var_def2);
+        assert!(old.is_some());
+        assert!(std::ptr::eq(old.unwrap(), var_def));
+
+        // Still only 1 variable (replaced)
+        assert_eq!(scope.variable_count(), 1);
+    }
+
+    #[test]
+    fn test_scope_stack_new() {
+        let stack: ScopeStack = ScopeStack::new();
+        assert_eq!(stack.scope_count(), 1);
+        assert_eq!(stack.current_scope_level(), 0);
+        assert!(!stack.in_with_context());
+    }
+
+    #[test]
+    fn test_scope_stack_push_pop() {
+        let mut stack = ScopeStack::new();
+        assert_eq!(stack.current_scope_level(), 0);
+
+        stack.push_scope();
+        assert_eq!(stack.current_scope_level(), 1);
+        assert_eq!(stack.scope_count(), 2);
+
+        stack.push_scope();
+        assert_eq!(stack.current_scope_level(), 2);
+        assert_eq!(stack.scope_count(), 3);
+
+        let scope = stack.pop_scope();
+        assert_eq!(scope.scope_level, 2);
+        assert_eq!(stack.current_scope_level(), 1);
+
+        let scope = stack.pop_scope();
+        assert_eq!(scope.scope_level, 1);
+        assert_eq!(stack.current_scope_level(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot pop the global scope")]
+    fn test_scope_stack_cannot_pop_global() {
+        let mut stack = ScopeStack::new();
+        stack.pop_scope(); // Should panic
+    }
+
+    #[test]
+    fn test_scope_stack_variable_lookup_with_shadowing() {
+        let arena = Bump::new();
+        let mut stack = ScopeStack::new();
+
+        // Declare x in global scope
+        let x_global = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            0,
+            dummy_span(),
+        ));
+        stack.declare_variable("x", x_global);
+
+        // Lookup should find global x
+        let found = stack.lookup_variable("x");
+        assert!(found.is_some());
+        assert!(std::ptr::eq(found.unwrap(), x_global));
+
+        // Enter new scope
+        stack.push_scope();
+
+        // Declare x in nested scope (shadows global x)
+        let x_nested = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            1,
+            dummy_span(),
+        ));
+        stack.declare_variable("x", x_nested);
+
+        // Lookup should find nested x (shadowing global x)
+        let found = stack.lookup_variable("x");
+        assert!(found.is_some());
+        assert!(std::ptr::eq(found.unwrap(), x_nested));
+
+        // Pop scope
+        stack.pop_scope();
+
+        // Lookup should find global x again
+        let found = stack.lookup_variable("x");
+        assert!(found.is_some());
+        assert!(std::ptr::eq(found.unwrap(), x_global));
+    }
+
+    #[test]
+    fn test_scope_stack_declare_same_scope_error() {
+        let arena = Bump::new();
+        let mut stack = ScopeStack::new();
+
+        let var1 = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            0,
+            dummy_span(),
+        ));
+
+        // First declaration succeeds
+        assert!(stack.declare_variable("x", var1).is_none());
+
+        let var2 = arena.alloc(VarDefinition::new(
+            "x",
+            dummy_span(),
+            None,
+            None,
+            0,
+            dummy_span(),
+        ));
+
+        // Second declaration in same scope returns error
+        let old = stack.declare_variable("x", var2);
+        assert!(old.is_some());
+        assert!(std::ptr::eq(old.unwrap(), var1));
+    }
+
+    #[test]
+    fn test_scope_stack_with_context() {
+        let arena = Bump::new();
+        let mut stack = ScopeStack::new();
+
+        // Initially not in with-context
+        assert!(!stack.in_with_context());
+        assert!(stack.current_with_context().is_none());
+
+        // Create a dummy type for the expression
+        let int_type = arena.alloc(crate::hir_types::ResolvedType::I32 { span: dummy_span() });
+
+        // Create a dummy with-context (transform context)
+        let ctx = arena.alloc(WithContext {
+            context_expr: arena.alloc(crate::hir_expr::ResolvedExpr {
+                span: dummy_span(),
+                kind: crate::hir_expr::ResolvedExprKind::IntLit { value: 42 },
+                ty: int_type,
+            }),
+            container_field: None,
+            transforms: vec![],
+        });
+
+        // Enter with-context
+        stack.enter_with_context(ctx);
+        assert!(stack.in_with_context());
+        assert_eq!(stack.scope_count(), 2);
+        assert_eq!(stack.current_scope_level(), 1);
+
+        let found_ctx = stack.current_with_context();
+        assert!(found_ctx.is_some());
+        assert!(std::ptr::eq(found_ctx.unwrap(), ctx));
+
+        // Exit with-context
+        let popped = stack.exit_with_context();
+        assert!(popped.has_with_context());
+        assert!(!stack.in_with_context());
+        assert_eq!(stack.scope_count(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "exit_with_context called but current scope has no with-context")]
+    fn test_scope_stack_exit_without_context() {
+        let mut stack = ScopeStack::new();
+        stack.push_scope();
+        stack.exit_with_context(); // Should panic - no with-context in current scope
+    }
+
+    #[test]
+    fn test_scope_stack_nested_with_contexts() {
+        let arena = Bump::new();
+        let mut stack = ScopeStack::new();
+
+        // Create a dummy type for the expressions
+        let int_type = arena.alloc(crate::hir_types::ResolvedType::I32 { span: dummy_span() });
+
+        // Create first with-context
+        let ctx1 = arena.alloc(WithContext {
+            context_expr: arena.alloc(crate::hir_expr::ResolvedExpr {
+                span: dummy_span(),
+                kind: crate::hir_expr::ResolvedExprKind::IntLit { value: 1 },
+                ty: int_type,
+            }),
+            container_field: None,
+            transforms: vec![],
+        });
+
+        stack.enter_with_context(ctx1);
+        assert_eq!(stack.current_scope_level(), 1);
+
+        // Create nested with-context
+        let ctx2 = arena.alloc(WithContext {
+            context_expr: arena.alloc(crate::hir_expr::ResolvedExpr {
+                span: dummy_span(),
+                kind: crate::hir_expr::ResolvedExprKind::IntLit { value: 2 },
+                ty: int_type,
+            }),
+            container_field: None,
+            transforms: vec![],
+        });
+
+        stack.enter_with_context(ctx2);
+        assert_eq!(stack.current_scope_level(), 2);
+
+        // Current with-context should be the innermost (ctx2)
+        let found = stack.current_with_context();
+        assert!(found.is_some());
+        assert!(std::ptr::eq(found.unwrap(), ctx2));
+
+        // Exit innermost with-context
+        stack.exit_with_context();
+        assert_eq!(stack.current_scope_level(), 1);
+
+        // Current with-context should now be ctx1
+        let found = stack.current_with_context();
+        assert!(found.is_some());
+        assert!(std::ptr::eq(found.unwrap(), ctx1));
+
+        // Exit outer with-context
+        stack.exit_with_context();
+        assert_eq!(stack.current_scope_level(), 0);
+        assert!(!stack.in_with_context());
+    }
+}

--- a/src/hir_types.rs
+++ b/src/hir_types.rs
@@ -1,0 +1,164 @@
+//! High-Level IR (HIR) Type Definitions
+//!
+//! This module defines the type system for the HIR, which represents types after
+//! name resolution and type checking have been performed.
+
+// Allow dead code for now since this module is not yet fully integrated
+#![allow(dead_code)]
+//!
+//! # Arena Allocation
+//!
+//! The HIR uses arena allocation via `bumpalo::Bump` for memory management. This
+//! approach offers several benefits:
+//!
+//! 1. **Performance**: Arena allocation is extremely fast - allocations are just
+//!    pointer bumps, and deallocation happens all at once when the arena is dropped.
+//!
+//! 2. **Lifetime Management**: By tying all HIR data to the arena's lifetime
+//!    (`'arena`), we get compile-time guarantees that HIR data won't outlive the
+//!    arena. This eliminates use-after-free bugs.
+//!
+//! 3. **Simplicity**: We can use direct references (`&'arena T`) instead of
+//!    reference-counted pointers or indices. The borrow checker ensures safety.
+//!
+//! 4. **Cache Locality**: Related data allocated together tends to be stored
+//!    nearby in memory, improving CPU cache performance.
+//!
+//! # Lifetime Parameters
+//!
+//! Types in this module have two lifetime parameters:
+//!
+//! - `'src`: Lifetime of the source code string. String slices (`&'src str`) point
+//!   directly into the original source, avoiding allocations.
+//!
+//! - `'arena`: Lifetime of the arena allocator. All HIR data structures allocated
+//!   in the arena share this lifetime.
+//!
+//! # Type Resolution
+//!
+//! `ResolvedType` represents types that have been fully resolved:
+//! - Primitive types (bool, i32, f64, real, algebraic) are represented directly
+//! - User-defined types include a reference to their struct definition
+//! - Reference types point to their inner type in the arena
+//!
+//! All types retain their original source spans for error reporting and tooling.
+
+use crate::ast::span::HasSpan;
+use crate::hir_definitions::StructDefinition;
+use crate::lexer::Span;
+
+// ============================================================================
+// Resolved Type System
+// ============================================================================
+
+/// A fully resolved type in the HIR
+///
+/// This represents a type after name resolution, where user-defined types
+/// have been linked to their definitions. All type data is allocated in
+/// the arena and referenced by `'arena` lifetime.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ResolvedType<'src, 'arena> {
+    /// Boolean type (`bool`)
+    Bool { span: Span },
+
+    /// 32-bit signed integer type (`i32`)
+    I32 { span: Span },
+
+    /// 64-bit floating point type (`f64`)
+    F64 { span: Span },
+
+    /// Mathematical real number with exact precision (`real`)
+    ///
+    /// Represents arbitrary-precision real numbers for geometric calculations
+    /// where floating-point errors are unacceptable.
+    Real { span: Span },
+
+    /// Algebraic number type (`algebraic`)
+    ///
+    /// Represents roots of polynomials with integer coefficients. This is
+    /// a subset of real numbers that can be represented exactly.
+    Algebraic { span: Span },
+
+    /// Reference type (e.g., `&Point`)
+    ///
+    /// The inner type is allocated in the arena, so this is a reference to
+    /// arena-allocated data, not a box.
+    Reference {
+        inner: &'arena ResolvedType<'src, 'arena>,
+        span: Span,
+    },
+
+    /// User-defined type (e.g., `Point`, `Circle`)
+    ///
+    /// Contains the type name and a reference to the struct definition in the
+    /// arena. This allows type checking to access field information and other
+    /// metadata.
+    UserDefined {
+        name: &'src str,
+        definition: &'arena StructDefinition<'src, 'arena>,
+        span: Span,
+    },
+}
+
+// ============================================================================
+// HasSpan Implementation
+// ============================================================================
+
+impl<'src, 'arena> HasSpan for ResolvedType<'src, 'arena> {
+    fn span(&self) -> Span {
+        match self {
+            ResolvedType::Bool { span } => *span,
+            ResolvedType::I32 { span } => *span,
+            ResolvedType::F64 { span } => *span,
+            ResolvedType::Real { span } => *span,
+            ResolvedType::Algebraic { span } => *span,
+            ResolvedType::Reference { span, .. } => *span,
+            ResolvedType::UserDefined { span, .. } => *span,
+        }
+    }
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+impl<'src, 'arena> ResolvedType<'src, 'arena> {
+    /// Returns true if this type is a primitive numeric type (i32, f64, real, algebraic)
+    pub fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            ResolvedType::I32 { .. }
+                | ResolvedType::F64 { .. }
+                | ResolvedType::Real { .. }
+                | ResolvedType::Algebraic { .. }
+        )
+    }
+
+    /// Returns true if this type is a reference type
+    pub fn is_reference(&self) -> bool {
+        matches!(self, ResolvedType::Reference { .. })
+    }
+
+    /// Returns true if this type is a user-defined type
+    pub fn is_user_defined(&self) -> bool {
+        matches!(self, ResolvedType::UserDefined { .. })
+    }
+
+    /// If this is a reference type, returns the inner type
+    pub fn as_reference(&self) -> Option<&'arena ResolvedType<'src, 'arena>> {
+        match self {
+            ResolvedType::Reference { inner, .. } => Some(inner),
+            _ => None,
+        }
+    }
+
+    /// If this is a user-defined type, returns the name and definition
+    pub fn as_user_defined(&self) -> Option<(&'src str, &'arena StructDefinition<'src, 'arena>)> {
+        match self {
+            ResolvedType::UserDefined {
+                name, definition, ..
+            } => Some((name, definition)),
+            _ => None,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,14 @@ mod ast;
 mod lexer;
 mod parser;
 
+// HIR modules
+mod hir;
+mod hir_context;
+mod hir_definitions;
+mod hir_expr;
+mod hir_scope;
+mod hir_types;
+
 use chumsky::Parser as _;
 use clap::{Parser, Subcommand};
 use lexer::TokenTrait;


### PR DESCRIPTION
Implements High-Level Intermediate Representation (HIR) using arena
allocation for efficient memory management and natural cross-references
between semantic nodes.

- Add bumpalo 3.16 dependency for arena allocation
- Create hir_types: Resolved type system with struct definition refs
- Create hir_definitions: Variable, function, struct, field definitions
- Create hir_expr: Resolved expressions with type info and def refs
- Create hir_context: With-statement context tracking for transforms
- Create hir_scope: Symbol table and scope stack with shadowing support
- Create hir: Main module with comprehensive documentation

All HIR nodes use 'arena lifetime for cross-references and 'src
lifetime for source text, enabling efficient graph structure without
Box/Rc overhead. Spans preserved throughout for error reporting.