### PR TITLE
Add global rune functions and struct params in rune blocks

### DIFF
--- a/examples/rune_blocks/global_rune_fn.cad
+++ b/examples/rune_blocks/global_rune_fn.cad
@@ -1,0 +1,28 @@
+// Example: Global Rune Functions
+//
+// Demonstrates `rune fn` declarations that are injected into every rune block's
+// compilation unit, enabling code reuse between multiple rune blocks.
+
+// Declare a global rune helper function (no type annotations needed — Rune is dynamically typed)
+rune fn square(x) {
+    x * x
+}
+
+rune fn hypotenuse(a, b) {
+    (square(a) + square(b)).sqrt()
+}
+
+let a: f64;
+let b: f64;
+a == 3.0;
+b == 4.0;
+
+// Call the global rune functions from a rune block
+let h = rune(a, b) {
+    hypotenuse(a, b)
+};
+
+// Another rune block calling the same global functions
+let sum_sq = rune(a, b) {
+    square(a) + square(b)
+};

--- a/examples/rune_blocks/struct_params.cad
+++ b/examples/rune_blocks/struct_params.cad
@@ -1,0 +1,30 @@
+// Example: Struct Parameters in Rune Blocks
+//
+// Demonstrates passing CAD-DSL struct variables to rune blocks.
+// Struct fields are automatically packed into a Rune Object so they
+// are accessible inside the rune block via dot notation (p.x, p.y, etc.).
+
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+// Global rune helper that operates on struct objects
+rune fn dist(a, b) {
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+let p1: Point;
+let p2: Point;
+
+p1.x == 0.0;
+p1.y == 0.0;
+p2.x == 3.0;
+p2.y == 4.0;
+
+// Pass struct variables as rune block parameters
+let d = rune(p1, p2) {
+    dist(p1, p2)
+};

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -389,6 +389,25 @@ pub enum Stmt<'src> {
     /// Include directive: `include "<path>";`
     /// Loads and splices another .cad file into the current program.
     Include { path: &'src str, span: Span },
+
+    /// Global rune function declaration: `rune fn name(p1, p2) { body }`
+    ///
+    /// Defines a Rune function that is injected into every rune block's compilation
+    /// unit, enabling code sharing across blocks. Parameters are dynamically typed
+    /// (Rune handles typing at runtime, no annotations needed).
+    ///
+    /// Examples:
+    ///   rune fn distance(a, b) { ... }
+    ///   rune fn norm(v) { (v.x * v.x + v.y * v.y).sqrt() }
+    GlobalRuneFn {
+        name: String,
+        name_span: Span,
+        /// Parameter names (no type annotations — Rune is dynamically typed)
+        params: Vec<&'src str>,
+        /// Raw Rune source for the function body (inside braces, stripped)
+        body: &'src str,
+        span: Span,
+    },
 }
 
 /// A single directive inside an optimize block
@@ -425,6 +444,7 @@ impl<'src> HasSpan for Stmt<'src> {
             Stmt::UnitDef { span, .. } => *span,
             Stmt::UnitPrefixDecl { span, .. } => *span,
             Stmt::Include { span, .. } => *span,
+            Stmt::GlobalRuneFn { span, .. } => *span,
         }
     }
 }

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -609,6 +609,15 @@ pub enum ResolvedStmtKind<'src, 'arena> {
         /// Span for the entire statement
         span: Span,
     },
+
+    /// Global rune function declaration
+    ///
+    /// Example: `rune fn distance(a, b) { let dx = a.x - b.x; ... }`
+    GlobalRuneFn {
+        /// Reconstructed Rune function definition string, ready to prepend to rune blocks.
+        /// Format: `fn name(p1, p2) { body }`
+        rune_fn_code: String,
+    },
 }
 
 // ============================================================================

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,8 +62,8 @@ pub use error::report_parse_errors;
 #[allow(unused_imports)] // Re-exported for public API and tests
 pub use stmt::{
     assignment_stmt, block_stmt, expression_stmt, field_assignment_stmt, for_stmt, function_def,
-    if_stmt, include_stmt, let_stmt, optimize_stmt, return_stmt, struct_def, unit_prefix_stmt,
-    unit_stmt, with_stmt,
+    global_rune_fn_def, if_stmt, include_stmt, let_stmt, optimize_stmt, return_stmt, struct_def,
+    unit_prefix_stmt, unit_stmt, with_stmt,
 };
 
 // ============================================================================
@@ -144,6 +144,7 @@ pub fn parse_program<'src>(
             unit_prefix_stmt(),
             unit_stmt(),
             include_stmt(),
+            global_rune_fn_def(Some(content)),
             struct_def(expr.clone()),
             function_def(expr.clone()),
             let_stmt(expr.clone()),

--- a/src/parser/atoms.rs
+++ b/src/parser/atoms.rs
@@ -102,7 +102,7 @@ fn rune_block<'src>(
 /// Parse the body of a rune block with bracket counting
 /// Returns a placeholder body string and the span from opening to closing brace
 /// The actual body text will be extracted during semantic analysis using the span
-fn rune_body<'src>()
+pub(crate) fn rune_body<'src>()
 -> impl Parser<'src, &'src [Token<'src>], (&'src str, Span), ParseError<'src>> + Clone {
     // Implementation with bracket counting as required by Phase 1.4
     // Strategy:
@@ -149,7 +149,7 @@ fn rune_body<'src>()
 // ============================================================================
 
 /// Extract source text from a span by converting line/column positions to byte offsets
-fn extract_source_from_span<'src>(source: &'src str, span: &Span) -> &'src str {
+pub(crate) fn extract_source_from_span<'src>(source: &'src str, span: &Span) -> &'src str {
     // Convert line/column to byte offset
     let mut byte_offset = 0;
     let mut current_line = 1;

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -1477,3 +1477,83 @@ pub fn include_stmt<'src>()
         })
         .labelled("include directive")
 }
+
+// ============================================================================
+// Global Rune Function Parser
+// ============================================================================
+
+/// Parse a global rune function declaration: `rune fn name(p1, p2) { body }`
+///
+/// Global rune functions are injected into every rune block's compilation unit,
+/// enabling code reuse. Parameters are untyped (Rune is dynamically typed).
+///
+/// Examples:
+///   rune fn distance(a, b) { ((a.x - b.x)^2 + (a.y - b.y)^2).sqrt() }
+///   rune fn norm(v) { (v.x * v.x + v.y * v.y).sqrt() }
+pub fn global_rune_fn_def<'src>(
+    source: Option<&'src str>,
+) -> impl Parser<'src, &'src [Token<'src>], Stmt<'src>, ParseError<'src>> + Clone {
+    use crate::parser::atoms::{extract_source_from_span, rune_body};
+
+    select! { Token::Rune(t) => t.position }
+        .then_ignore(select! { Token::Fn(_) => () })
+        .then(
+            select! { Token::Identifier(t) => (t.name.to_string(), t.span) }
+                .labelled("rune function name"),
+        )
+        .then(
+            // Parameter list: just identifier names (no type annotations)
+            select! { Token::Identifier(t) => t.name }
+                .separated_by(select! { Token::Comma(_) => () })
+                .allow_trailing()
+                .collect::<Vec<_>>()
+                .delimited_by(
+                    select! { Token::LeftParen(_) => () },
+                    select! { Token::RightParen(_) => () },
+                ),
+        )
+        .then(rune_body())
+        .map_with(
+            move |(((rune_pos, (name, name_span)), params), (_, body_span)), e| {
+                let span_range = e.span();
+
+                // Extract actual body text from source if available
+                let body = if let Some(src) = source {
+                    let full_body = extract_source_from_span(src, &body_span);
+                    full_body
+                        .trim()
+                        .strip_prefix('{')
+                        .unwrap_or(full_body)
+                        .trim()
+                        .strip_suffix('}')
+                        .unwrap_or(full_body)
+                        .trim()
+                } else {
+                    ""
+                };
+
+                let span = if rune_pos.line == body_span.start.line + body_span.lines {
+                    Span {
+                        start: rune_pos,
+                        lines: body_span.lines,
+                        end_column: span_range.end + 1,
+                    }
+                } else {
+                    Span {
+                        start: rune_pos,
+                        lines: 0,
+                        end_column: span_range.end + 1,
+                    }
+                };
+
+                Stmt::GlobalRuneFn {
+                    name,
+                    name_span,
+                    params,
+                    body,
+                    span,
+                }
+            },
+        )
+        .labelled("global rune function declaration")
+}

--- a/src/parser/tests/stmt_declarations.rs
+++ b/src/parser/tests/stmt_declarations.rs
@@ -41,6 +41,7 @@ fn test_let_with_type_and_init() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -81,6 +82,7 @@ fn test_let_with_type_only() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -121,6 +123,7 @@ fn test_let_with_init_only() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -161,6 +164,7 @@ fn test_let_no_type_no_init() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -217,6 +221,7 @@ fn test_let_with_expression() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -262,6 +267,7 @@ fn test_let_container_field_simple() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -307,6 +313,7 @@ fn test_let_container_field_nested() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -348,6 +355,7 @@ fn test_let_container_field_with_expression() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -389,6 +397,7 @@ fn test_let_container_field_no_type() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -433,6 +442,7 @@ fn test_let_container_field_deeply_nested() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 
@@ -483,6 +493,7 @@ fn test_let_container_field_span_tracking() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 

--- a/src/parser/tests/types_and_spans.rs
+++ b/src/parser/tests/types_and_spans.rs
@@ -294,6 +294,7 @@ fn test_span_let_statement() {
         | Stmt::UnitDef { .. }
         | Stmt::UnitPrefixDecl { .. }
         | Stmt::Include { .. } => panic!("Unexpected unit/include stmt"),
+        Stmt::GlobalRuneFn { .. } => panic!("Unexpected GlobalRuneFn stmt"),
     }
 }
 

--- a/src/semantic_analyzer/pass2.rs
+++ b/src/semantic_analyzer/pass2.rs
@@ -231,6 +231,21 @@ pub fn resolve_statement<'src, 'arena>(
         // and include resolver (not yet implemented); skip gracefully.
         Stmt::UnitDecl { .. } | Stmt::UnitDef { .. } | Stmt::UnitPrefixDecl { .. } => None,
         Stmt::Include { .. } => None,
+
+        Stmt::GlobalRuneFn {
+            name,
+            params,
+            body,
+            span,
+            ..
+        } => {
+            let params_str = params.join(", ");
+            let rune_fn_code = format!("fn {}({}) {{ {} }}", name, params_str, body);
+            Some(ctx.arena.alloc(ResolvedStmt::new(
+                *span,
+                ResolvedStmtKind::GlobalRuneFn { rune_fn_code },
+            )))
+        }
     }
 }
 

--- a/src/solver/context.rs
+++ b/src/solver/context.rs
@@ -257,6 +257,10 @@ pub struct SolverContext<'src, 'arena> {
     /// Rune blocks that need to be executed after constraint solving
     rune_blocks: Vec<RuneBlockExecution<'src, 'arena>>,
 
+    /// Global rune function definitions collected from `GlobalRuneFn` statements.
+    /// These are prepended to every rune block's compilation unit to enable code reuse.
+    global_rune_fns: Vec<String>,
+
     /// Current iteration number (for diagnostics)
     iteration: usize,
 
@@ -328,6 +332,7 @@ impl<'src, 'arena> SolverContext<'src, 'arena> {
             function_return_exprs: HashMap::new(),
             deferred_constraints: Vec::new(),
             rune_blocks: Vec::new(),
+            global_rune_fns: Vec::new(),
             iteration: 0,
             current_solution: None,
             previous_solved_count: 0,
@@ -894,14 +899,16 @@ impl<'src, 'arena> SolverContext<'src, 'arena> {
         // The HIR stores `I32` as a placeholder return type for rune blocks (it is
         // set during semantic analysis before the type checker runs).  Re-derive the
         // actual return type from the parameter types using the same heuristic as the
-        // type checker: if any parameter is f64 / Real / Algebraic the result is f64,
-        // otherwise fall back to the HIR-provided type (i32 or whatever).
+        // type checker: if any parameter is f64 / Real / Algebraic / struct / array
+        // the result is f64, otherwise fall back to the HIR-provided type.
         let effective_return_type = if params.iter().any(|p| {
             matches!(
                 p.value.ty,
                 ResolvedType::F64 { .. }
                     | ResolvedType::Real { .. }
                     | ResolvedType::Algebraic { .. }
+                    | ResolvedType::UserDefined { .. }
+                    | ResolvedType::Array { .. }
             )
         }) {
             self.arena.alloc(ResolvedType::F64 {
@@ -911,9 +918,9 @@ impl<'src, 'arena> SolverContext<'src, 'arena> {
             return_type
         };
 
-        // Compile the rune code once and cache it
+        // Compile the rune code once and cache it (with global fns prepended)
         let executor = RuneExecutor::new()?;
-        let compiled_unit = executor.compile_rune_block(body, &params)?;
+        let compiled_unit = executor.compile_rune_block(body, &params, &self.global_rune_fns)?;
 
         self.rune_blocks.push(RuneBlockExecution {
             result_path,
@@ -1207,29 +1214,63 @@ impl<'src, 'arena> SolverContext<'src, 'arena> {
         let rune_blocks = self.rune_blocks.clone();
 
         for rune_block in &rune_blocks {
-            // Extract parameter values from solution
-            let mut param_values = Vec::new();
+            // Build Rune argument values for each parameter.
+            // Primitives (i32, f64, bool) are looked up directly by path.
+            // Struct/array parameters are assembled from all sub-paths with the param's
+            // path as a prefix, then packed into a Rune Object.
+            let mut rune_args: Vec<rune::Value> = Vec::new();
 
             for param in &rune_block.params {
-                // Resolve the parameter expression to get its value.
-                // Supports Var (simple variable) and FieldAccess (e.g. p.x after
-                // method-call substitution).
                 let path = resolve_rune_param_path(param.value, self)?;
-                let value = solution.assignments.get(&path).cloned().ok_or_else(|| {
-                    SolverError::RuneExecutionError(format!(
-                        "Rune block parameter '{}' not found in solution",
-                        path
-                    ))
-                })?;
 
-                param_values.push(value);
+                if let Some(value) = solution.assignments.get(&path) {
+                    // Primitive value found directly — convert to Rune value
+                    let rune_val = executor
+                        .convert_to_rune_value(value, param.value.ty)
+                        .map_err(SolverError::from)?;
+                    rune_args.push(rune_val);
+                } else {
+                    // No direct primitive — collect all sub-paths that start with this path
+                    // (e.g., param path = [Field("p")], solution has [Field("p"), Field("x")], ...)
+                    let param_components = path.components();
+                    let mut struct_fields: Vec<(Vec<String>, Value)> = Vec::new();
+
+                    for (sol_path, sol_value) in &solution.assignments {
+                        let sol_components = sol_path.components();
+                        // Check if sol_components starts with param_components
+                        if sol_components.len() > param_components.len()
+                            && sol_components.starts_with(param_components)
+                        {
+                            // Build the relative path (components after the param prefix)
+                            let relative: Vec<String> = sol_components[param_components.len()..]
+                                .iter()
+                                .map(|c| match c {
+                                    PathComponent::Field(f) => f.to_string(),
+                                    PathComponent::Index(i) => i.to_string(),
+                                })
+                                .collect();
+                            struct_fields.push((relative, sol_value.clone()));
+                        }
+                    }
+
+                    if struct_fields.is_empty() {
+                        return Err(SolverError::RuneExecutionError(format!(
+                            "Rune block parameter '{}' not found in solution (no direct value or sub-fields)",
+                            path
+                        )));
+                    }
+
+                    let rune_obj = executor
+                        .build_rune_object(struct_fields)
+                        .map_err(SolverError::from)?;
+                    rune_args.push(rune_obj);
+                }
             }
 
             // Execute the rune block with pre-compiled unit (no recompilation)
-            let result = executor.execute_compiled_block(
+            let result = executor.execute_compiled_block_with_rune_values(
                 rune_block.compiled_unit.clone(),
-                &rune_block.params,
-                param_values,
+                rune_args,
             )?;
 
             // Convert result back to solver value
@@ -1264,6 +1305,15 @@ impl<'src, 'arena> SolverContext<'src, 'arena> {
     ) -> Result<SolveResult<'src>, SolverError> {
         use crate::hir::expr::ResolvedStmtKind;
         use crate::solver::Solvable;
+
+        // Pre-pass to collect global rune function definitions (before any rune blocks are compiled)
+        for stmt in statements {
+            if let ResolvedStmtKind::GlobalRuneFn { rune_fn_code } = &stmt.kind
+                && !self.global_rune_fns.contains(rune_fn_code)
+            {
+                self.global_rune_fns.push(rune_fn_code.clone());
+            }
+        }
 
         // Pre-pass to register all function return expressions for correct scoping
         for stmt in statements {

--- a/src/solver/impls/stmt.rs
+++ b/src/solver/impls/stmt.rs
@@ -270,6 +270,10 @@ impl<'src, 'arena> Solvable<'src, 'arena> for ResolvedStmt<'src, 'arena> {
                 Ok(())
             }
 
+            // Global rune function declarations are collected in the pre-pass of solve();
+            // at statement execution time they are a no-op.
+            ResolvedStmtKind::GlobalRuneFn { .. } => Ok(()),
+
             // Unsupported statements
             _ => Err(SolverError::UnsupportedStatement(format!(
                 "{:?}",

--- a/src/solver/rune_executor.rs
+++ b/src/solver/rune_executor.rs
@@ -146,18 +146,21 @@ impl RuneExecutor {
     ///
     /// This method compiles the rune code once and returns an Arc<Unit>
     /// that can be cached and reused for multiple executions with different parameters.
+    /// `global_fns` are prepended to the compilation unit so the rune block can call them.
     pub fn compile_rune_block<'src, 'arena>(
         &self,
         body: &str,
         params: &[ResolvedRuneParam<'src, 'arena>],
+        global_fns: &[String],
     ) -> Result<Arc<Unit>, RuneExecutionError> {
-        let rune_code = self.generate_rune_code(body, params)?;
+        let rune_code = self.generate_rune_code(body, params, global_fns)?;
         self.compile_rune_code(&rune_code)
     }
 
     /// Execute a pre-compiled rune block with the given parameter values
     ///
     /// This method reuses a cached compiled Unit, avoiding recompilation.
+    #[allow(dead_code)] // Available for external callers; internally we use execute_compiled_block_with_rune_values
     pub fn execute_compiled_block<'src, 'arena>(
         &self,
         compiled_unit: Arc<Unit>,
@@ -178,17 +181,128 @@ impl RuneExecutor {
         Ok(result)
     }
 
-    /// Generate complete Rune code from a rune block body and parameters
+    /// Build a Rune `Object` from a flat map of relative field paths to `Value`s.
     ///
+    /// `fields` is a `Vec<(Vec<String>, Value)>` where each element is a relative
+    /// path (e.g., `["x"]` or `["start", "x"]`) and its value.  The values are
+    /// packed into nested Rune Objects so Rune code can access them as `v.x`,
+    /// `v.start.x`, etc.
+    ///
+    /// This is used to pass CAD-DSL struct variables (stored in Z3 as separate
+    /// flattened primitives) as a single dynamically-typed Rune Object.
+    pub fn build_rune_object(
+        &self,
+        fields: Vec<(Vec<String>, Value)>,
+    ) -> Result<RuneValue, RuneExecutionError> {
+        // Build a nested tree first, then convert to Rune Objects bottom-up.
+        // We represent the tree as a HashMap of String -> NestedNode.
+        #[derive(Default)]
+        struct NestedNode {
+            value: Option<Value>,
+            children: std::collections::HashMap<String, NestedNode>,
+        }
+
+        let mut root = NestedNode::default();
+        for (path_parts, val) in fields {
+            let mut node = &mut root;
+            for (i, part) in path_parts.iter().enumerate() {
+                node = node.children.entry(part.clone()).or_default();
+                if i == path_parts.len() - 1 {
+                    node.value = Some(val.clone());
+                }
+            }
+        }
+
+        fn node_to_rune(node: NestedNode) -> Result<RuneValue, RuneExecutionError> {
+            if node.children.is_empty() {
+                // Leaf node — convert primitive value
+                let v = node
+                    .value
+                    .ok_or_else(|| RuneExecutionError::ConversionError {
+                        message: "Empty node with no value".to_string(),
+                    })?;
+                match v {
+                    Value::Int(i) => Ok(RuneValue::from(i)),
+                    Value::Real(f) => Ok(RuneValue::from(f)),
+                    Value::Bool(b) => Ok(RuneValue::from(b)),
+                    Value::UnderConstrained => Err(RuneExecutionError::ConversionError {
+                        message: "Cannot pass under-constrained field to rune block".to_string(),
+                    }),
+                }
+            } else {
+                // Branch node — build Rune Object
+                let mut obj = rune::runtime::Object::new();
+                for (key, child) in node.children {
+                    let rune_key = rune::alloc::String::try_from(key.as_str()).map_err(|e| {
+                        RuneExecutionError::ConversionError {
+                            message: format!("Failed to allocate key string: {}", e),
+                        }
+                    })?;
+                    let child_value = node_to_rune(child)?;
+                    obj.insert(rune_key, child_value).map_err(|e| {
+                        RuneExecutionError::ConversionError {
+                            message: format!("Failed to insert field into Rune Object: {}", e),
+                        }
+                    })?;
+                }
+                RuneValue::new(obj).map_err(|e| RuneExecutionError::ConversionError {
+                    message: format!("Failed to wrap Rune Object as Value: {}", e),
+                })
+            }
+        }
+
+        // The root is a synthetic parent — we return a Rune Object of its children
+        let mut obj = rune::runtime::Object::new();
+        for (key, child) in root.children {
+            let rune_key = rune::alloc::String::try_from(key.as_str()).map_err(|e| {
+                RuneExecutionError::ConversionError {
+                    message: format!("Failed to allocate key string: {}", e),
+                }
+            })?;
+            let child_value = node_to_rune(child)?;
+            obj.insert(rune_key, child_value)
+                .map_err(|e| RuneExecutionError::ConversionError {
+                    message: format!("Failed to insert field into Rune Object: {}", e),
+                })?;
+        }
+        RuneValue::new(obj).map_err(|e| RuneExecutionError::ConversionError {
+            message: format!("Failed to wrap Rune Object as Value: {}", e),
+        })
+    }
+
+    /// Execute a pre-compiled rune block with pre-built `RuneValue` arguments.
+    ///
+    /// Unlike `execute_compiled_block`, this method accepts values that have
+    /// already been converted to `RuneValue` (including Rune Objects for structs).
+    pub fn execute_compiled_block_with_rune_values(
+        &self,
+        compiled_unit: Arc<Unit>,
+        rune_args: Vec<RuneValue>,
+    ) -> Result<RuneValue, RuneExecutionError> {
+        self.execute_rune_function(compiled_unit, rune_args)
+    }
+
+    /// Generate complete Rune code from a rune block body, parameters, and global fns.
+    ///
+    /// Global function definitions are prepended so the rune block body can call them.
     /// Creates a wrapper function that can be compiled and executed by Rune.
     fn generate_rune_code<'src, 'arena>(
         &self,
         body: &str,
         params: &[ResolvedRuneParam<'src, 'arena>],
+        global_fns: &[String],
     ) -> Result<String, RuneExecutionError> {
-        let mut code = String::from("pub fn __rune_fn__(");
+        let mut code = String::new();
 
-        // Add parameters (types will be inferred by Rune)
+        // Prepend global rune function definitions
+        for fn_code in global_fns {
+            code.push_str(fn_code);
+            code.push('\n');
+        }
+
+        code.push_str("pub fn __rune_fn__(");
+
+        // Add parameters (types are omitted — Rune is dynamically typed at the executor level)
         for (i, param) in params.iter().enumerate() {
             if i > 0 {
                 code.push_str(", ");

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -284,6 +284,14 @@ pub fn type_check<'src, 'arena>(
     // Create type checking context
     let mut ctx = TypeCheckContext::new(arena, source);
 
+    // Pre-pass: collect global rune function definitions so they can be injected
+    // into every rune block's compilation unit.
+    for stmt in hir {
+        if let crate::hir::expr::ResolvedStmtKind::GlobalRuneFn { rune_fn_code } = &stmt.kind {
+            ctx.add_global_rune_fn(rune_fn_code.clone());
+        }
+    }
+
     // Validate each statement in the HIR
     for stmt in hir {
         validation::validate_stmt(&mut ctx, stmt);

--- a/src/type_checker/context.rs
+++ b/src/type_checker/context.rs
@@ -49,6 +49,9 @@ pub struct TypeCheckContext<'src, 'arena> {
     errors: Vec<TypeCheckError>,
     /// Collected type checking warnings
     warnings: Vec<String>,
+    /// Global rune function definitions (collected from GlobalRuneFn statements)
+    /// Each entry is a complete `fn name(params) { body }` string.
+    global_rune_fns: Vec<String>,
 }
 
 impl<'src, 'arena> TypeCheckContext<'src, 'arena> {
@@ -60,7 +63,18 @@ impl<'src, 'arena> TypeCheckContext<'src, 'arena> {
             type_constraints: Vec::new(),
             errors: Vec::new(),
             warnings: Vec::new(),
+            global_rune_fns: Vec::new(),
         }
+    }
+
+    /// Register a global rune function definition
+    pub fn add_global_rune_fn(&mut self, code: String) {
+        self.global_rune_fns.push(code);
+    }
+
+    /// Get all registered global rune function definitions
+    pub fn global_rune_fns(&self) -> &[String] {
+        &self.global_rune_fns
     }
 
     /// Add a type constraint to the context

--- a/src/type_checker/inference.rs
+++ b/src/type_checker/inference.rs
@@ -416,7 +416,8 @@ pub fn infer_expr_type<'src, 'arena>(
                 }
             };
 
-            match rune_checker.infer_return_type(body, params, expr.span) {
+            let global_fns: Vec<String> = ctx.global_rune_fns().to_vec();
+            match rune_checker.infer_return_type(body, params, &global_fns, expr.span) {
                 Ok((inferred_type, diagnostics)) => {
                     // Add any warnings to the context (errors were already handled separately)
                     if !diagnostics.is_empty() {

--- a/src/type_checker/rune_integration.rs
+++ b/src/type_checker/rune_integration.rs
@@ -139,6 +139,7 @@ impl RuneTypeChecker {
     ///
     /// * `body` - The raw Rune code body (as string from source)
     /// * `params` - The resolved parameters with their types
+    /// * `global_fns` - Global rune function definitions to prepend to the compilation unit
     /// * `span` - Source span for error reporting
     ///
     /// # Returns
@@ -148,10 +149,11 @@ impl RuneTypeChecker {
         &self,
         body: &str,
         params: &[ResolvedRuneParam<'src, 'arena>],
+        global_fns: &[String],
         span: Span,
     ) -> Result<(ResolvedType<'src, 'arena>, Diagnostics), RuneTypeCheckError> {
         // Generate a complete Rune function wrapper
-        let rune_code = self.generate_rune_function(body, params)?;
+        let rune_code = self.generate_rune_function(body, params, global_fns)?;
 
         // Compile the Rune code
         let mut sources = Sources::new();
@@ -202,21 +204,40 @@ impl RuneTypeChecker {
     /// Generate a complete Rune function from a rune block body and parameters
     ///
     /// This creates a wrapper function that Rune can compile and type-check.
+    /// Global rune function definitions are prepended before the wrapper function.
     fn generate_rune_function<'src, 'arena>(
         &self,
         body: &str,
         params: &[ResolvedRuneParam<'src, 'arena>],
+        global_fns: &[String],
     ) -> Result<String, RuneTypeCheckError> {
-        let mut code = String::from("pub fn __rune_fn__(");
+        let mut code = String::new();
 
-        // Add parameters with their Rune types
+        // Prepend global rune function definitions
+        for fn_code in global_fns {
+            code.push_str(fn_code);
+            code.push('\n');
+        }
+
+        code.push_str("pub fn __rune_fn__(");
+
+        // Add parameters; for struct/array types we omit the type annotation since
+        // those values will be passed as Rune Objects (dynamically typed).
         for (i, param) in params.iter().enumerate() {
             if i > 0 {
                 code.push_str(", ");
             }
             code.push_str(param.name);
-            code.push_str(": ");
-            code.push_str(&self.map_type_to_rune(param.value.ty)?);
+            // Only add a type annotation for primitive types that Rune can verify
+            match param.value.ty {
+                ResolvedType::UserDefined { .. } | ResolvedType::Array { .. } => {
+                    // No type annotation — value arrives as a Rune Object
+                }
+                _ => {
+                    code.push_str(": ");
+                    code.push_str(&self.map_type_to_rune(param.value.ty)?);
+                }
+            }
         }
 
         code.push_str(") {\n");
@@ -249,20 +270,11 @@ impl RuneTypeChecker {
                 // Algebraic numbers can be approximated as f64 in Rune
                 Ok("f64".to_string())
             }
-            ResolvedType::UserDefined { name, span, .. } => {
-                Err(RuneTypeCheckError::UnsupportedType {
-                    type_name: name.to_string(),
-                    _span: *span,
-                    message: "Struct types in rune blocks not yet supported (planned for Phase 6)"
-                        .to_string(),
-                })
-            }
-            ResolvedType::Array { span, .. } => Err(RuneTypeCheckError::UnsupportedType {
-                type_name: "Array".to_string(),
-                _span: *span,
-                message: "Array types in rune blocks not yet supported (planned for Phase 6)"
-                    .to_string(),
-            }),
+            // Struct and array types are passed as Rune Objects (no annotation needed).
+            // This branch is only reached if the caller explicitly needs a type name string;
+            // `generate_rune_function` skips calling this for UserDefined/Array params.
+            ResolvedType::UserDefined { name, .. } => Ok(format!("/* {} */", name)),
+            ResolvedType::Array { .. } => Ok("/* array */".to_string()),
             ResolvedType::Reference { span, .. } => Err(RuneTypeCheckError::UnsupportedType {
                 type_name: "Reference".to_string(),
                 _span: *span,
@@ -279,18 +291,22 @@ impl RuneTypeChecker {
     /// # Heuristic
     ///
     /// - If any parameter is f64, real, or algebraic → return f64
+    /// - If any parameter is a struct (UserDefined) or array → return f64
+    ///   (geometric computations on structs commonly return floats)
     /// - Otherwise → return i32
     fn infer_type_from_params<'src, 'arena>(
         &self,
         params: &[ResolvedRuneParam<'src, 'arena>],
         span: Span,
     ) -> ResolvedType<'src, 'arena> {
-        // Check if any parameter is a floating-point type
+        // Check if any parameter is a floating-point or composite type
         for param in params {
             match param.value.ty {
                 ResolvedType::F64 { .. }
                 | ResolvedType::Real { .. }
-                | ResolvedType::Algebraic { .. } => {
+                | ResolvedType::Algebraic { .. }
+                | ResolvedType::UserDefined { .. }
+                | ResolvedType::Array { .. } => {
                     return ResolvedType::F64 { span };
                 }
                 _ => {}
@@ -367,7 +383,7 @@ mod tests {
 
         // This should compile successfully (even though it references undefined x)
         // The Rune compiler will handle parameter validation
-        let code = checker.generate_rune_function(body, &params);
+        let code = checker.generate_rune_function(body, &params, &[]);
         assert!(code.is_ok());
 
         let code = code.unwrap();
@@ -392,7 +408,7 @@ mod tests {
             0.0f64
         "#;
 
-        let result = checker.infer_return_type(body, &[], span);
+        let result = checker.infer_return_type(body, &[], &[], span);
         assert!(
             result.is_ok(),
             "Type checker must compile env::var() calls; \

--- a/src/type_checker/validation.rs
+++ b/src/type_checker/validation.rs
@@ -188,6 +188,10 @@ pub fn validate_stmt<'src, 'arena>(
                 }
             }
         }
+
+        // Global rune function declarations need no validation — they are pure Rune code
+        // that will be type-checked by the Rune compiler when injected into rune blocks.
+        ResolvedStmtKind::GlobalRuneFn { .. } => {}
     }
 }
 

--- a/tests/fixtures/solve/rune_global_fn.cad
+++ b/tests/fixtures/solve/rune_global_fn.cad
@@ -1,0 +1,20 @@
+rune fn square(x) {
+    x * x
+}
+
+rune fn hypotenuse(a, b) {
+    (square(a) + square(b)).sqrt()
+}
+
+let a: f64;
+let b: f64;
+a == 3.0;
+b == 4.0;
+
+let h = rune(a, b) {
+    hypotenuse(a, b)
+};
+
+let sum_sq = rune(a, b) {
+    square(a) + square(b)
+};

--- a/tests/fixtures/solve/rune_struct_params.cad
+++ b/tests/fixtures/solve/rune_struct_params.cad
@@ -1,0 +1,22 @@
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+rune fn dist(a, b) {
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+let p1: Point;
+let p2: Point;
+
+p1.x == 0.0;
+p1.y == 0.0;
+p2.x == 3.0;
+p2.y == 4.0;
+
+let d = rune(p1, p2) {
+    dist(p1, p2)
+};

--- a/tests/solver_integration_test.rs
+++ b/tests/solver_integration_test.rs
@@ -1740,3 +1740,43 @@ fn test_rune_file_read() {
     verify_solution(&stdout, "x", "7");
     verify_solution(&stdout, "read_ok", "1");
 }
+
+// ============================================================================
+// Global Rune Functions (Part A)
+// ============================================================================
+
+#[test]
+fn test_rune_global_fn() {
+    // Test global rune fn declarations that are injected into every rune block.
+    // `square(x)` and `hypotenuse(a, b)` are defined globally and called from
+    // two separate rune blocks.
+    let (success, stdout, stderr) = solve_fixture("rune_global_fn.cad");
+    assert!(success, "Solver failed: {}{}", stdout, stderr);
+
+    verify_solution(&stdout, "a", "3");
+    verify_solution(&stdout, "b", "4");
+    // hypotenuse(3, 4) = sqrt(9 + 16) = sqrt(25) = 5
+    verify_solution(&stdout, "h", "5");
+    // square(3) + square(4) = 9 + 16 = 25
+    verify_solution(&stdout, "sum_sq", "25");
+}
+
+// ============================================================================
+// Struct Parameters in Rune Blocks (Part B)
+// ============================================================================
+
+#[test]
+fn test_rune_struct_params() {
+    // Test that CAD-DSL struct variables can be passed to rune blocks.
+    // The solver packs flattened Z3 primitives (p1.x, p1.y, ...) into
+    // Rune Objects so the rune code can access them as p1.x, p1.y, etc.
+    let (success, stdout, stderr) = solve_fixture("rune_struct_params.cad");
+    assert!(success, "Solver failed: {}{}", stdout, stderr);
+
+    verify_solution(&stdout, "p1.x", "0");
+    verify_solution(&stdout, "p1.y", "0");
+    verify_solution(&stdout, "p2.x", "3");
+    verify_solution(&stdout, "p2.y", "4");
+    // dist(p1, p2) = sqrt((3-0)^2 + (4-0)^2) = sqrt(9 + 16) = sqrt(25) = 5
+    verify_solution(&stdout, "d", "5");
+}


### PR DESCRIPTION
Part A - Global Rune Functions:
- New top-level `rune fn name(params) { body }` syntax
- Injected into every rune block's compilation unit so blocks can
  call shared helper functions defined at program scope
- Tracked through the full pipeline: AST (GlobalRuneFn variant) →
  parser (global_rune_fn_def combinator) → HIR (ResolvedStmtKind) →
  semantic pass2 → type checker pre-pass → solver pre-pass

Part B - Struct Parameters in Rune Blocks:
- CAD-DSL struct variables (e.g. `p: Point`) can now be passed
  directly to rune blocks as parameters
- Solver collects all flattened Z3 sub-primitives (p.x, p.y, …)
  via prefix matching on VariablePath and packs them into a Rune
  runtime Object, making fields accessible as `p.x`, `p.y` inside
  Rune code via dot notation
- Type annotations omitted for struct/array params in the generated
  Rune wrapper (Rune is dynamically typed for Object values)
- Return type heuristic promoted to f64 for UserDefined/Array params

Includes integration tests (rune_global_fn.cad, rune_struct_params.cad)
and example .cad files documenting both features.

https://claude.ai/code/session_017vWJcv9udBrbVqqvEmdV9Y