### PR TITLE
Use tempfile crate for unique test temp files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "rune",
  "rune-alloc",
  "subenum",
+ "tempfile",
  "z3",
 ]
 
@@ -326,6 +327,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -740,6 +757,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1382,6 +1405,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1653,19 @@ name = "syntree"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c99c9cda412afe293a6b962af651b4594161ba88c1affe7ef66459ea040a06"
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ z3 = "0.19.7"
 
 [dev-dependencies]
 assert_matches = "1.5"
+tempfile = "3"

--- a/tests/hir_transform_tests.rs
+++ b/tests/hir_transform_tests.rs
@@ -13,15 +13,22 @@
 //! not unit tests. Unit tests for internal types should be added to the
 //! relevant source modules using #[cfg(test)].
 
+use std::io::Write;
 use std::process::Command;
 
 /// Helper function to run the solve command on a test file
-fn solve_test(test_code: &str, test_name: &str) -> (bool, String, String) {
-    let test_file = format!("/tmp/{}.cad", test_name);
-    std::fs::write(&test_file, test_code).unwrap();
+fn solve_test(test_code: &str) -> (bool, String, String) {
+    let mut temp_file = tempfile::Builder::new()
+        .suffix(".cad")
+        .tempfile()
+        .expect("Failed to create temp file");
+    temp_file
+        .write_all(test_code.as_bytes())
+        .expect("Failed to write temp file");
+    let path = temp_file.path().to_owned();
 
     let output = Command::new("cargo")
-        .args(["run", "--", "solve", &test_file])
+        .args(["run", "--", "solve", path.to_str().unwrap()])
         .output()
         .expect("Failed to execute command");
 
@@ -29,8 +36,7 @@ fn solve_test(test_code: &str, test_name: &str) -> (bool, String, String) {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let _ = std::fs::remove_file(&test_file);
-
+    // temp_file is dropped here, automatically deleting the file
     (success, stdout, stderr)
 }
 
@@ -88,7 +94,7 @@ with sketch {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_transform_simple");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -165,7 +171,7 @@ with t {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_nested_transforms");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -224,7 +230,7 @@ with sketch {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_multiple_vars");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -261,7 +267,7 @@ with c {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_container_no_transform");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -320,7 +326,7 @@ with sketch {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_external_var");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -373,7 +379,7 @@ with t {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_external_nested");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -432,7 +438,7 @@ with sketch {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_external_array");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -494,7 +500,7 @@ with sketch {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_mixed_vars");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -568,7 +574,7 @@ with t1 {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_three_level_chain");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -645,7 +651,7 @@ with sketch2 {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_independent_contexts");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -681,7 +687,7 @@ p.x == 10;
 p.y == 20;
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_no_transform");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -709,7 +715,7 @@ with c {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_simple_container");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -743,7 +749,7 @@ arr[1] == arr[0] + 1;
 arr[2] == arr[1] + 1;
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_regression_basic");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -809,7 +815,7 @@ with t1 {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_type_compatibility");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,
@@ -845,7 +851,7 @@ with c {
 }
 "#;
 
-    let (success, stdout, stderr) = solve_test(test_code, "test_qualified_names");
+    let (success, stdout, stderr) = solve_test(test_code);
 
     assert!(
         success,

--- a/tests/solver_comparison_test.rs
+++ b/tests/solver_comparison_test.rs
@@ -10,17 +10,24 @@
 //!
 //! Tests use the solver as a black box via CLI to validate end-to-end behavior.
 
+use std::io::Write;
 use std::process::Command;
 use std::time::Instant;
 
 /// Helper to run the solve command and measure time
-fn solve_with_timing(test_code: &str, test_name: &str) -> (bool, String, String, u128) {
-    let temp_file = format!("/tmp/{}.cad", test_name);
-    std::fs::write(&temp_file, test_code).unwrap();
+fn solve_with_timing(test_code: &str) -> (bool, String, String, u128) {
+    let mut temp_file = tempfile::Builder::new()
+        .suffix(".cad")
+        .tempfile()
+        .expect("Failed to create temp file");
+    temp_file
+        .write_all(test_code.as_bytes())
+        .expect("Failed to write temp file");
+    let path = temp_file.path().to_owned();
 
     let start = Instant::now();
     let output = Command::new("cargo")
-        .args(["run", "--", "solve", &temp_file])
+        .args(["run", "--", "solve", path.to_str().unwrap()])
         .output()
         .expect("Failed to execute command");
     let duration = start.elapsed().as_micros();
@@ -29,8 +36,7 @@ fn solve_with_timing(test_code: &str, test_name: &str) -> (bool, String, String,
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    std::fs::remove_file(&temp_file).ok();
-
+    // temp_file is dropped here, automatically deleting the file
     (success, stdout, stderr, duration)
 }
 
@@ -38,7 +44,7 @@ fn solve_with_timing(test_code: &str, test_name: &str) -> (bool, String, String,
 fn verify_solver(test_name: &str, source: &str, expected_vars: &[(&str, &str)]) {
     println!("\n=== {} ===", test_name);
 
-    let (success, stdout, stderr, duration) = solve_with_timing(source, test_name);
+    let (success, stdout, stderr, duration) = solve_with_timing(source);
 
     assert!(success, "Solver failed: {}{}", stdout, stderr);
     println!("Solved in: {}μs", duration);

--- a/tests/solver_performance_test.rs
+++ b/tests/solver_performance_test.rs
@@ -3,17 +3,24 @@
 //! These tests measure solver performance on various problem sizes and complexities.
 //! They are designed to track performance regressions and identify bottlenecks.
 
+use std::io::Write;
 use std::process::Command;
 use std::time::Instant;
 
 /// Helper to run the solve command and measure time
-fn solve_with_timing(test_code: &str, test_name: &str) -> (bool, String, String, u128) {
-    let temp_file = format!("/tmp/{}.cad", test_name);
-    std::fs::write(&temp_file, test_code).unwrap();
+fn solve_with_timing(test_code: &str) -> (bool, String, String, u128) {
+    let mut temp_file = tempfile::Builder::new()
+        .suffix(".cad")
+        .tempfile()
+        .expect("Failed to create temp file");
+    temp_file
+        .write_all(test_code.as_bytes())
+        .expect("Failed to write temp file");
+    let path = temp_file.path().to_owned();
 
     let start = Instant::now();
     let output = Command::new("cargo")
-        .args(["run", "--", "solve", &temp_file])
+        .args(["run", "--", "solve", path.to_str().unwrap()])
         .output()
         .expect("Failed to execute command");
     let duration = start.elapsed().as_millis();
@@ -22,8 +29,7 @@ fn solve_with_timing(test_code: &str, test_name: &str) -> (bool, String, String,
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    std::fs::remove_file(&temp_file).ok();
-
+    // temp_file is dropped here, automatically deleting the file
     (success, stdout, stderr, duration)
 }
 
@@ -44,7 +50,7 @@ y + z == 15;
 x + z == 13;
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_small_linear");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("Small linear system (3 vars): {}ms", duration);
 
@@ -115,7 +121,7 @@ p9.x == p8.x + 10;
 p9.y == p8.y + 5;
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_medium_struct");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("Medium struct system (10 points, 20 vars): {}ms", duration);
 
@@ -156,7 +162,7 @@ arr[18] == arr[17] + 1;
 arr[19] == arr[18] + 1;
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_array");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("Array system (20 elements): {}ms", duration);
 
@@ -196,7 +202,7 @@ points[0].y == 0;
         test_code.push_str(&format!("points[{}].y == points[{}].y + 1;\n", i, i - 1));
     }
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(&test_code, "perf_large_array");
+    let (success, _stdout, stderr, duration) = solve_with_timing(&test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!(
         "Large array of structs (50 points, 100 vars): {}ms",
@@ -265,7 +271,7 @@ r3.bottom_right.end.x == r3.top_left.start.x + 10;
 r3.bottom_right.end.y == r3.top_left.start.y + 10;
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_nested_structs");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("Complex nested structs (3 rectangles): {}ms", duration);
 
@@ -309,7 +315,7 @@ result2 == multiply(x, y);
 result3 == add(result1, result2);
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_functions");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("Function call system: {}ms", duration);
 
@@ -339,7 +345,7 @@ for i in 0..n {
 }
 "#;
 
-    let (success, _stdout, stderr, duration) = solve_with_timing(test_code, "perf_for_loop");
+    let (success, _stdout, stderr, duration) = solve_with_timing(test_code);
     assert!(success, "Solver failed: {}", stderr);
     println!("For-loop unrolling (20 iterations): {}ms", duration);
 


### PR DESCRIPTION
Three integration test helpers were writing CAD source to hardcoded
/tmp/<name>.cad paths. Tests running in parallel (or concurrent CI
workers) could clobber each other's files, causing flaky failures.

Replace all three helpers with tempfile::Builder so each test gets
a uniquely-named temp file that is automatically cleaned up when the
NamedTempFile handle is dropped. The test_name parameter is removed
from the helpers since it was only needed for uniqueness.

Affected files:
- tests/hir_transform_tests.rs (solve_test)
- tests/solver_comparison_test.rs (solve_with_timing)
- tests/solver_performance_test.rs (solve_with_timing)

https://claude.ai/code/session_01FqRc3K8ykJF8ECeky9joSG